### PR TITLE
add windows to ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 dist: bionic
 sudo: false
 
@@ -16,7 +17,7 @@ stages:
 install: true
 
 # Default script is the "test" stage
-script: 
+script:
   - cargo build
   - cargo test
   - examples/build_examples.sh


### PR DESCRIPTION
i am sorry, I only recently noticed some tests were not passing on windows, even if it builds.
do you want to add windows target to the ci pipeline and try to take it from there to see if it makes sense to address those issues?
thanks