### PR TITLE
Allow iteration over DB when key is empty byte slice

### DIFF
--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -289,6 +289,7 @@ mod tests {
     use super::*;
     use crate::db_impl::testutil::*;
     use crate::db_impl::DB;
+    use crate::options;
     use crate::test_util::LdbIteratorIter;
     use crate::types::{current_key_val, Direction};
 
@@ -484,5 +485,14 @@ mod tests {
                 assert!(!non_existing.contains(&k));
             }
         }
+    }
+
+    #[test]
+    fn db_iter_allow_empty_key() {
+        let opt = options::for_test();
+        let mut db = DB::open("db", opt).unwrap();
+        assert!(db.new_iter().unwrap().next().is_none());
+        db.put(&[], &[]).unwrap();
+        assert!(db.new_iter().unwrap().next().is_some());
     }
 }

--- a/src/key_types.rs
+++ b/src/key_types.rs
@@ -209,7 +209,7 @@ pub fn cmp_internal_key<'a, 'b>(
 /// truncate_to_userkey performs an in-place conversion from InternalKey to UserKey format.
 pub fn truncate_to_userkey(ikey: &mut Vec<u8>) {
     let len = ikey.len();
-    assert!(len > 8);
+    assert!(len >= 8);
     ikey.truncate(len - 8);
 }
 


### PR DESCRIPTION
`truncate_to_userkey` contained an off-by-one error.

The added test fails without this change.

This closes #16.