### PR TITLE
fix the panic-when-recovering problem

### DIFF
--- a/src/db_impl.rs
+++ b/src/db_impl.rs
@@ -806,7 +806,7 @@ impl DB {
             // TODO: Do we need to do a memtable compaction here? Probably not, in the sequential
             // case.
             assert!(input.current(&mut key, &mut val));
-            if cs.compaction.should_stop_before(&key) && cs.builder.is_none() {
+            if cs.compaction.should_stop_before(&key) && cs.builder.is_some() {
                 self.finish_compaction_output(cs, key.clone())?;
             }
             let (ktyp, seq, ukey) = parse_internal_key(&key);

--- a/src/version_set.rs
+++ b/src/version_set.rs
@@ -676,25 +676,23 @@ impl VersionSet {
                 return false;
             }
             if let Ok(size) = self.opt.env.size_of(Path::new(current_manifest_path)) {
-                if size > self.opt.max_file_size {
+                if size >= self.opt.max_file_size {
                     return false;
                 }
-            } else {
-                return false;
-            }
 
-            assert!(self.descriptor_log.is_none());
-            let s = self
-                .opt
-                .env
-                .open_appendable_file(Path::new(current_manifest_path));
-            if let Ok(f) = s {
-                log!(self.opt.log, "reusing manifest {:?}", current_manifest_path);
-                self.descriptor_log = Some(LogWriter::new(f));
-                self.manifest_num = num;
-                return true;
-            } else {
-                log!(self.opt.log, "reuse_manifest: {}", s.err().unwrap());
+                assert!(self.descriptor_log.is_none());
+                let s = self
+                    .opt
+                    .env
+                    .open_appendable_file(Path::new(current_manifest_path));
+                if let Ok(f) = s {
+                    log!(self.opt.log, "reusing manifest {:?}", current_manifest_path);
+                    self.descriptor_log = Some(LogWriter::new_with_off(f, size));
+                    self.manifest_num = num;
+                    return true;
+                } else {
+                    log!(self.opt.log, "reuse_manifest: {}", s.err().unwrap());
+                }
             }
         }
         false


### PR DESCRIPTION
1. use new_with_off to recover LogWriter's offset.
2. run finish_compaction_output only when the builder exists.