### PR TITLE
Do compactions after writing memtables (#34)

### DIFF
--- a/src/db_impl.rs
+++ b/src/db_impl.rs
@@ -719,6 +719,9 @@ impl DB {
         }
         ve.set_log_num(self.log_num.unwrap_or(0));
         self.vset.borrow_mut().log_and_apply(ve)?;
+        if let Err(e) = self.maybe_do_compaction() {
+            log!(self.opt.log, "Wanted to do compaction, but failed: {}", e);
+        }
         if let Err(e) = self.delete_obsolete_files() {
             log!(self.opt.log, "Error deleting obsolete files: {}", e);
         }
@@ -949,6 +952,7 @@ impl DB {
 
 impl Drop for DB {
     fn drop(&mut self) {
+        self.flush().ok();
         let _ = self.release_lock();
     }
 }


### PR DESCRIPTION
@Sword-Smith I managed to reproduce the behavior you saw, and agree that it is untenable. Writing more and more L0 tables for some reason doesn't trigger a compaction. Therefore I attempted a brute-force approach - this definitely helps in my experiment. Maybe you can beta-test it for a few days?