### PR TITLE
feature: Hide `PosixDiskEnv` type behind a feature (default enabled)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["cdylib", "rlib"]
 crc = "1.8"
 integer-encoding = "3.0"
 rand = "0.7"
+getrandom = { optional = true, version = "0.2.10", features = ["js"] }
 snap = "1.0"
 
 errno = { optional = true, version = "0.2" }
@@ -28,6 +29,7 @@ tokio = { optional = true, features = ["rt", "sync"], version = ">= 1.21" }
 
 [features]
 default = ["fs"]
+wasm = ["getrandom"]
 async = ["tokio"]
 fs = ["errno", "fs2"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,24 @@ publish = true
 edition = "2018"
 include = ["src/**/*", "src/*", "Cargo.toml", "LICENSE", "README.md"]
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 crc = "1.8"
 integer-encoding = "3.0"
 rand = "0.7"
 snap = "1.0"
-errno = "0.2"
-fs2 = "0.4.3"
+
+errno = { optional = true, version = "0.2" }
+fs2 = {optional = true, version = "0.4.3"}
 
 tokio = { optional = true, features = ["rt", "sync"], version = ">= 1.21" }
 
 [features]
-default = []
+default = ["fs"]
 async = ["tokio"]
+fs = ["errno", "fs2"]
 
 [dev-dependencies]
 time-test = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ crate-type = ["cdylib", "rlib"]
 crc = "1.8"
 integer-encoding = "3.0"
 rand = "0.8.5"
-getrandom = { optional = true, version = "0.2.10", features = ["js"] }
 snap = "1.0"
 
 errno = { optional = true, version = "0.2" }
@@ -29,7 +28,6 @@ tokio = { optional = true, features = ["rt", "sync"], version = ">= 1.21" }
 
 [features]
 default = ["fs"]
-wasm = ["getrandom"]
 async = ["tokio"]
 fs = ["errno", "fs2"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 crc = "1.8"
 integer-encoding = "3.0"
-rand = "0.7"
+rand = "0.8.5"
 getrandom = { optional = true, version = "0.2.10", features = ["js"] }
 snap = "1.0"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,9 @@ use std::io;
 use std::result;
 use std::sync;
 
+#[cfg(feature = "fs")]
 use errno;
+
 use snap;
 
 /// StatusCode describes various failure modes of database operations.
@@ -26,6 +28,7 @@ pub enum StatusCode {
     PermissionDenied,
     AsyncError,
     Unknown,
+    #[cfg(feature = "fs")]
     Errno(errno::Errno),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ mod cmp;
 #[cfg(feature = "fs")]
 mod disk_env;
 
-mod env;
 mod env_common;
 mod error;
 mod filter;
@@ -81,6 +80,7 @@ mod write_batch;
 mod db_impl;
 mod db_iter;
 
+pub mod env;
 pub mod compressor;
 
 #[cfg(feature = "async")]
@@ -94,7 +94,6 @@ pub use db_iter::DBIterator;
 #[cfg(feature = "fs")]
 pub use disk_env::PosixDiskEnv;
 
-pub use env::{Env, FileLock, RandomAccess, Logger};
 pub use error::{Result, Status, StatusCode};
 pub use filter::{BloomPolicy, FilterPolicy};
 pub use mem_env::MemEnv;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub use db_iter::DBIterator;
 #[cfg(feature = "fs")]
 pub use disk_env::PosixDiskEnv;
 
-pub use env::Env;
+pub use env::{Env, FileLock, RandomAccess, Logger};
 pub use error::{Result, Status, StatusCode};
 pub use filter::{BloomPolicy, FilterPolicy};
 pub use mem_env::MemEnv;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,13 @@
 #![allow(dead_code)]
 
 extern crate crc;
+
+#[cfg(feature = "fs")]
 extern crate errno;
+
+#[cfg(feature = "fs")]
 extern crate fs2;
+
 extern crate integer_encoding;
 extern crate rand;
 extern crate snap;
@@ -45,7 +50,10 @@ mod block_builder;
 mod blockhandle;
 mod cache;
 mod cmp;
+
+#[cfg(feature = "fs")]
 mod disk_env;
+
 mod env;
 mod env_common;
 mod error;
@@ -82,7 +90,10 @@ pub use cmp::{Cmp, DefaultCmp};
 pub use compressor::{Compressor, CompressorId};
 pub use db_impl::DB;
 pub use db_iter::DBIterator;
+
+#[cfg(feature = "fs")]
 pub use disk_env::PosixDiskEnv;
+
 pub use env::Env;
 pub use error::{Result, Status, StatusCode};
 pub use filter::{BloomPolicy, FilterPolicy};

--- a/src/options.rs
+++ b/src/options.rs
@@ -49,16 +49,16 @@ pub struct Options {
 }
 
 #[cfg(feature = "fs")]
-type CurrentEnv = crate::disk_env::PosixDiskEnv;
+type DefaultEnv = crate::disk_env::PosixDiskEnv;
 
 #[cfg(not(feature = "fs"))]
-type CurrentEnv = crate::mem_env::MemEnv;
+type DefaultEnv = crate::mem_env::MemEnv;
 
 impl Default for Options {
     fn default() -> Options {
         Options {
             cmp: Rc::new(Box::new(DefaultCmp)),
-            env: Rc::new(Box::new(CurrentEnv::new())),
+            env: Rc::new(Box::new(DefaultEnv::new())),
             log: None,
             create_if_missing: true,
             error_if_exists: false,

--- a/src/options.rs
+++ b/src/options.rs
@@ -6,7 +6,7 @@ use crate::env::Env;
 use crate::infolog::{self, Logger};
 use crate::mem_env::MemEnv;
 use crate::types::{share, Shared};
-use crate::{disk_env, Result};
+use crate::Result;
 use crate::{filter, Status, StatusCode};
 
 use std::default::Default;
@@ -48,11 +48,17 @@ pub struct Options {
     pub filter_policy: filter::BoxedFilterPolicy,
 }
 
+#[cfg(feature = "fs")]
+type CurrentEnv = crate::disk_env::PosixDiskEnv;
+
+#[cfg(not(feature = "fs"))]
+type CurrentEnv = crate::mem_env::MemEnv;
+
 impl Default for Options {
     fn default() -> Options {
         Options {
             cmp: Rc::new(Box::new(DefaultCmp)),
-            env: Rc::new(Box::new(disk_env::PosixDiskEnv::new())),
+            env: Rc::new(Box::new(CurrentEnv::new())),
             log: None,
             create_if_missing: true,
             error_if_exists: false,


### PR DESCRIPTION
Building `rusty-leveldb` in constrained or non-POSIX environments (such as WASM) is currently not possible.
This PR adds small changes to make it possible.

## Changes
- Introduces `fs` feature which is enabled by default. The feature allows to toggle the `PosixDiskEnv` type and therefore makes it possible to build `rusty-leveldb` on systems where `std::io` is constrained. One major use case are WASM environments. Users can therefore set `use-default-features = false` on `rusty-leveldb` dependency entries in their `Cargo.toml` . The only available `Env` will be `MemEnv` if `fs` feature is disabled.

- Updates `rand` crate to version `0.8.5` which is also WASM compatible. When the users of `rusty-leveldb` add `getrandom` dependency to their `Cargo.toml`, it will make the random number generation in `rusty-leveldb` work on their platform.

- Adds `crate-type` to allow builds in different environments
- Re-exports `FileLock`, `RandomAccessFile` and `Logger` types so that users can add custom implementation of the `Env` trait.