### PR TITLE
Use Bytes instead of Vec<u8> to reduce memory allocations and improve performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/**/*", "src/*", "Cargo.toml", "LICENSE", "README.md"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-crc = "3.2"
+crc32c = "0.6.8"
 integer-encoding = "3.0"
 bytes = "1.10.1"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 crc = "3.2"
 integer-encoding = "3.0"
+bytes = "1.10.1"
 rand = "0.8.5"
 snap = "1.0"
 

--- a/examples/kvserver/src/main.rs
+++ b/examples/kvserver/src/main.rs
@@ -16,7 +16,7 @@ impl KVService {
         rp.set_content_type("text/plain");
 
         if let Some(val) = val {
-            rp.append(val);
+            rp.append(val.to_vec());
         } else {
             rp.set_status(404);
         }

--- a/examples/leveldb-tool/src/main.rs
+++ b/examples/leveldb-tool/src/main.rs
@@ -34,7 +34,7 @@ fn iter(db: &mut DB) {
     let (mut k, mut v) = (vec![], vec![]);
     let mut out = io::BufWriter::new(io::stdout());
     while it.advance() {
-        it.current();
+        (k, v) = it.current();
         out.write_all(&k).unwrap();
         out.write_all(b" => ").unwrap();
         out.write_all(&v).unwrap();

--- a/examples/leveldb-tool/src/main.rs
+++ b/examples/leveldb-tool/src/main.rs
@@ -9,7 +9,7 @@ use std::iter::FromIterator;
 fn get(db: &mut DB, k: &str) {
     match db.get(k.as_bytes()) {
         Some(v) => {
-            if let Ok(s) = String::from_utf8(v.clone()) {
+            if let Ok(s) = String::from_utf8(v.to_vec().into()) {
                 eprintln!("{} => {}", k, s);
             } else {
                 eprintln!("{} => {:?}", k, v);
@@ -34,7 +34,7 @@ fn iter(db: &mut DB) {
     let (mut k, mut v) = (vec![], vec![]);
     let mut out = io::BufWriter::new(io::stdout());
     while it.advance() {
-        it.current(&mut k, &mut v);
+        it.current();
         out.write_all(&k).unwrap();
         out.write_all(b" => ").unwrap();
         out.write_all(&v).unwrap();

--- a/examples/mcpe/src/main.rs
+++ b/examples/mcpe/src/main.rs
@@ -100,5 +100,5 @@ fn main() {
     let mut db = DB::open(PATH, opt).unwrap();
     db.put(b"~local_player", b"NBT data goes here").unwrap();
     let value = db.get(b"~local_player").unwrap();
-    assert_eq!(&value, b"NBT data goes here")
+    assert_eq!(&*value, b"NBT data goes here")
 }

--- a/examples/mcpe/src/main.rs
+++ b/examples/mcpe/src/main.rs
@@ -100,5 +100,5 @@ fn main() {
     let mut db = DB::open(PATH, opt).unwrap();
     db.put(b"~local_player", b"NBT data goes here").unwrap();
     let value = db.get(b"~local_player").unwrap();
-    assert_eq!(&*value, b"NBT data goes here")
+    assert_eq!(value, b"NBT data goes here")
 }

--- a/examples/word-analyze/src/main.rs
+++ b/examples/word-analyze/src/main.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 fn update_count(w: &str, db: &mut leveldb::DB) -> Option<()> {
     let mut count: usize = 0;
     if let Some(v) = db.get(w.as_bytes()) {
-        let s = String::from_utf8(v).unwrap();
+        let s = String::from_utf8(v.into()).unwrap();
         count = s.parse::<usize>().unwrap();
     }
     count += 1;

--- a/src/asyncdb.rs
+++ b/src/asyncdb.rs
@@ -187,7 +187,8 @@ impl AsyncDB {
                                 send_response(message.resp_channel, Response::Error(e));
                             }
                             Ok(v) => {
-                                send_response(message.resp_channel, Response::Value(v));
+                                let v_vec = v.map(|bytes| bytes.to_vec());
+                                send_response(message.resp_channel, Response::Value(v_vec));
                             }
                         };
                     } else {
@@ -201,7 +202,7 @@ impl AsyncDB {
                     }
                 }
                 Request::Get { key } => {
-                    let r = db.get(&key);
+                    let r = db.get(&key).map(|bytes| bytes.to_vec());
                     send_response(message.resp_channel, Response::Value(r));
                 }
                 Request::GetSnapshot => {

--- a/src/benches/db_bench.rs
+++ b/src/benches/db_bench.rs
@@ -1,0 +1,852 @@
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use rusty_leveldb::{
+    compressor::{self, CompressorId},
+    LdbIterator, Options, WriteBatch, DB,
+};
+use std::hint::black_box;
+use std::time::Duration; // Added for specifying measurement times
+
+use tempfile::TempDir;
+
+// Only include AsyncDB and runtimes if the corresponding features are enabled
+#[cfg(feature = "asyncdb-tokio")]
+use rusty_leveldb::AsyncDB as TokioAsyncDB;
+#[cfg(feature = "asyncdb-tokio")]
+use tokio::runtime::Runtime;
+
+#[cfg(feature = "asyncdb-async-std")]
+use async_std::task as async_std_task;
+#[cfg(feature = "asyncdb-async-std")]
+use rusty_leveldb::AsyncDB as AsyncStdAsyncDB;
+
+use rand::rngs::StdRng;
+use rand::{distributions::Alphanumeric, Rng, RngCore, SeedableRng};
+
+// --- Helper Functions ---
+
+fn get_default_options() -> Options {
+    let mut opts = Options::default();
+    #[cfg(feature = "fs")]
+    {
+        opts.env = std::rc::Rc::new(Box::new(rusty_leveldb::PosixDiskEnv::new()));
+    }
+    opts.create_if_missing = true;
+    opts
+}
+
+fn generate_kv(key_len: usize, val_len: usize, rng: &mut impl Rng) -> (Vec<u8>, Vec<u8>) {
+    let key: String = std::iter::repeat(())
+        .map(|()| rng.sample(Alphanumeric))
+        .map(char::from)
+        .take(key_len)
+        .collect();
+    let value: String = std::iter::repeat(())
+        .map(|()| rng.sample(Alphanumeric))
+        .map(char::from)
+        .take(val_len)
+        .collect();
+    (key.into_bytes(), value.into_bytes())
+}
+
+// --- Synchronous DB Benchmarks ---
+
+fn db_put_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DB_Put");
+    let key_len = 16;
+    let val_len = 100;
+
+    for &comp_id in [
+        compressor::NoneCompressor::ID,
+        compressor::SnappyCompressor::ID,
+    ]
+    .iter()
+    {
+        let comp_name = if comp_id == compressor::NoneCompressor::ID {
+            "None"
+        } else {
+            "Snappy"
+        };
+        group.bench_with_input(
+            BenchmarkId::from_parameter(comp_name),
+            &comp_id,
+            |b, &ci| {
+                let temp_dir = TempDir::new().unwrap();
+                let mut opts = get_default_options();
+                opts.compressor = ci;
+                let mut db = DB::open(temp_dir.path(), opts).unwrap();
+                let mut rng = StdRng::seed_from_u64(123);
+
+                b.iter_batched_ref(
+                    || generate_kv(key_len, val_len, &mut rng),
+                    |kv_pair| {
+                        db.put(black_box(&kv_pair.0), black_box(&kv_pair.1))
+                            .unwrap();
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn db_get_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DB_Get");
+    let key_len = 16;
+    let val_len = 100;
+    let num_items = 10_000; // Note: The provided log shows Get times in ms, suggesting DB setup might be part of each iteration.
+                            // If only 'get' op is to be measured, DB setup should be outside b.iter/b.iter_batched setup.
+                            // Current structure benchmarks "open + populate + get" for each sample.
+
+    for &comp_id in [
+        compressor::NoneCompressor::ID,
+        compressor::SnappyCompressor::ID,
+    ]
+    .iter()
+    {
+        let comp_name = if comp_id == compressor::NoneCompressor::ID {
+            "None"
+        } else {
+            "Snappy"
+        };
+
+        let populate_temp_dir = TempDir::new().unwrap(); // Base data for cloning
+        let mut opts = get_default_options();
+        opts.compressor = comp_id;
+
+        let mut populate_rng = StdRng::seed_from_u64(42);
+        let kvs: Vec<(Vec<u8>, Vec<u8>)> = (0..num_items)
+            .map(|_| generate_kv(key_len, val_len, &mut populate_rng))
+            .collect();
+
+        // Pre-populate a template DB once to speed up fresh DB creation if needed,
+        // though the original code creates and populates fully fresh DBs in each iter_batched setup.
+        // We'll stick to the original logic of full setup per sample as provided.
+        {
+            let mut db = DB::open(populate_temp_dir.path(), opts.clone()).unwrap();
+            for (key, value) in &kvs {
+                db.put(key, value).unwrap();
+            }
+            db.flush().unwrap();
+        }
+
+        group.bench_function(BenchmarkId::new("Existing", comp_name), |b| {
+            let mut rng = StdRng::seed_from_u64(234);
+            b.iter_batched(
+                || {
+                    let idx = rng.gen_range(0..num_items);
+                    let key = kvs[idx].0.clone();
+                    let fresh_temp_dir = TempDir::new().unwrap();
+                    let mut fresh_db = DB::open(fresh_temp_dir.path(), opts.clone()).unwrap();
+                    for (k, v) in &kvs {
+                        // Re-populating for each sample.
+                        fresh_db.put(k, v).unwrap();
+                    }
+                    fresh_db.flush().unwrap();
+                    (fresh_db, key, fresh_temp_dir)
+                },
+                |(mut db, key_to_get, _temp_dir)| {
+                    assert!(db.get(black_box(&key_to_get)).is_some());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        let non_existing_key_gen_rng = &mut StdRng::seed_from_u64(345);
+        let non_existing_key = generate_kv(key_len, val_len, non_existing_key_gen_rng).0;
+        group.bench_function(BenchmarkId::new("NonExisting", comp_name), |b| {
+            b.iter_batched(
+                || {
+                    let fresh_temp_dir = TempDir::new().unwrap();
+                    let mut fresh_db = DB::open(fresh_temp_dir.path(), opts.clone()).unwrap();
+                    for (k, v) in &kvs {
+                        // Re-populating for each sample.
+                        fresh_db.put(k, v).unwrap();
+                    }
+                    fresh_db.flush().unwrap();
+                    (fresh_db, non_existing_key.clone(), fresh_temp_dir)
+                },
+                |(mut db, key, _temp_dir)| {
+                    assert!(db.get(black_box(&key)).is_none());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn db_delete_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DB_Delete");
+    let key_len = 16;
+    let val_len = 100;
+    //let _num_items_init = 1000; // Original variable, not directly used in current logic.
+
+    for &comp_id in [
+        compressor::NoneCompressor::ID,
+        compressor::SnappyCompressor::ID,
+    ]
+    .iter()
+    {
+        let comp_name = if comp_id == compressor::NoneCompressor::ID {
+            "None"
+        } else {
+            "Snappy"
+        };
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(comp_name),
+            &comp_id,
+            |b, &ci| {
+                let mut opts = get_default_options();
+                opts.compressor = ci;
+
+                b.iter_batched(
+                    || {
+                        let fresh_temp_dir = TempDir::new().unwrap();
+                        let mut db = DB::open(fresh_temp_dir.path(), opts.clone()).unwrap();
+                        // Using thread_rng to seed StdRng for variety in keys per iteration,
+                        // but still deterministic if the parent thread's RNG sequence is fixed.
+                        let mut thread_rng = rand::thread_rng();
+                        let mut rng = StdRng::seed_from_u64(thread_rng.next_u64());
+                        let (key, value) = generate_kv(key_len, val_len, &mut rng);
+                        db.put(&key, &value).unwrap();
+                        db.flush().unwrap();
+                        (db, key, fresh_temp_dir)
+                    },
+                    |(mut db, key_to_delete, _temp_dir)| {
+                        db.delete(black_box(&key_to_delete)).unwrap();
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn db_write_batch_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DB_WriteBatch");
+    // Apply suggested warmup for DB_WriteBatch/Batch1000_Snappy (target time to 8.3s)
+    // This will apply to all benchmarks in this group. If other batch sizes become too slow,
+    // consider separate groups or more complex conditional configuration.
+    group.measurement_time(Duration::from_secs_f64(8.3));
+
+    let key_len = 16;
+    let val_len = 100;
+
+    for batch_size in [10, 100, 1000].iter() {
+        for &comp_id in [
+            compressor::NoneCompressor::ID,
+            compressor::SnappyCompressor::ID,
+        ]
+        .iter()
+        {
+            let comp_name = if comp_id == compressor::NoneCompressor::ID {
+                "None"
+            } else {
+                "Snappy"
+            };
+            let bench_id_str = format!("Batch{}_{}", batch_size, comp_name);
+
+            group.throughput(Throughput::Elements(*batch_size as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(bench_id_str), // Use custom string for BenchmarkId
+                &(*batch_size, comp_id),
+                |b, &(bs, ci)| {
+                    // Note: temp_dir is created for each parameter set, but DB is opened once per set.
+                    // For iter_batched, if DB setup is part of the routine, it runs per sample.
+                    // Here, DB is setup once, then iter_batched reuses it.
+                    let temp_dir = TempDir::new().unwrap();
+                    let mut opts = get_default_options();
+                    opts.compressor = ci;
+                    let mut db = DB::open(temp_dir.path(), opts).unwrap();
+                    let mut rng = StdRng::seed_from_u64(456); // Fixed seed for key generation across iterations of iter_batched
+
+                    // Pre-generate KVs for the batch. These KVs will be the same for every batch write in this specific benchmark setup.
+                    // If you need different KVs for each batch.write, move this inside the setup closure of iter_batched.
+                    let kvs_for_batch: Vec<_> = (0..bs)
+                        .map(|_| generate_kv(key_len, val_len, &mut rng))
+                        .collect();
+
+                    b.iter_batched(
+                        || {
+                            // Setup: create the WriteBatch
+                            let mut batch = WriteBatch::default();
+                            for (key, value) in &kvs_for_batch {
+                                // Using pre-generated KVs
+                                batch.put(key, value);
+                            }
+                            batch
+                        },
+                        |batch_to_write| {
+                            // Routine: write the batch
+                            db.write(black_box(batch_to_write), false).unwrap();
+                        },
+                        BatchSize::SmallInput, // Each batch write is one operation
+                    );
+                    // db and temp_dir are dropped here after all iterations for this parameter set.
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+fn db_iteration_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DB_Iteration");
+    // Apply suggested warmup for DB_Iteration/Items1000_Snappy (target time to 8.6s)
+    group.measurement_time(Duration::from_secs_f64(8.6));
+
+    let key_len = 16;
+    let val_len = 100;
+
+    for &num_items in [1_000, 10_000].iter() {
+        for &comp_id in [
+            compressor::NoneCompressor::ID,
+            compressor::SnappyCompressor::ID,
+        ]
+        .iter()
+        {
+            let comp_name = if comp_id == compressor::NoneCompressor::ID {
+                "None"
+            } else {
+                "Snappy"
+            };
+            let bench_id_str = format!("Items{}_{}", num_items, comp_name);
+
+            let mut opts = get_default_options(); // Base options
+            opts.compressor = comp_id;
+
+            // Pre-generate the KVs that will be used to populate each fresh database.
+            let mut populate_rng = StdRng::seed_from_u64(42); // Consistent seed for data generation
+            let kvs_to_populate: Vec<(Vec<u8>, Vec<u8>)> = (0..num_items)
+                .map(|_| generate_kv(key_len, val_len, &mut populate_rng))
+                .collect();
+
+            group.throughput(Throughput::Elements(num_items as u64));
+            group.bench_function(BenchmarkId::from_parameter(bench_id_str), |b| {
+                // iter_batched creates a fresh DB for each sample. This measures "create+populate+iterate".
+                b.iter_batched(
+                    || {
+                        // Setup: Create and populate a fresh DB
+                        let fresh_temp_dir = TempDir::new().unwrap();
+                        let mut fresh_db = DB::open(fresh_temp_dir.path(), opts.clone()).unwrap();
+                        for (key, value) in &kvs_to_populate {
+                            fresh_db.put(key, value).unwrap();
+                        }
+                        fresh_db.flush().unwrap();
+                        (fresh_db, fresh_temp_dir) // Pass DB and temp_dir to the routine
+                    },
+                    |(mut db, _temp_dir_to_drop)| {
+                        // Routine: Iterate over the DB
+                        let mut iter = db.new_iter().unwrap();
+                        let mut count = 0;
+                        while iter.advance() {
+                            // Optionally black_box(iter.key()) and black_box(iter.value())
+                            count += 1;
+                        }
+                        assert_eq!(count, num_items);
+                        black_box(count); // Ensure count is used
+                                          // _temp_dir_to_drop is dropped here, cleaning up the DB files for this sample
+                    },
+                    BatchSize::SmallInput, // Indicates setup is relatively quick per iteration
+                );
+            });
+        }
+    }
+    group.finish();
+}
+
+fn db_snapshot_get_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DB_Snapshot_Get");
+    // Apply suggested warmup for DB_Snapshot_Get/* (target time to 5.8s)
+    group.measurement_time(Duration::from_secs_f64(5.8));
+
+    let key_len = 16;
+    let val_len = 100;
+    let num_items = 1000;
+
+    for &comp_id in [
+        compressor::NoneCompressor::ID,
+        compressor::SnappyCompressor::ID,
+    ]
+    .iter()
+    {
+        let comp_name = if comp_id == compressor::NoneCompressor::ID {
+            "None"
+        } else {
+            "Snappy"
+        };
+
+        let mut opts = get_default_options(); // Base options
+        opts.compressor = comp_id;
+
+        // Pre-generate KVs for initial population and for modifications.
+        let mut rng_populate = StdRng::seed_from_u64(42); // Consistent seed
+        let kvs_initial: Vec<(Vec<u8>, Vec<u8>)> = (0..num_items)
+            .map(|_| generate_kv(key_len, val_len, &mut rng_populate))
+            .collect();
+        let (extra_key, extra_val) = generate_kv(key_len, val_len, &mut rng_populate);
+
+        group.bench_function(BenchmarkId::from_parameter(comp_name), |b| {
+            let mut rng_bench_iter = StdRng::seed_from_u64(333); // For picking keys per iteration
+
+            // iter_batched creates a fresh DB, populates, snapshots, modifies, then gets from snapshot for each sample.
+            // This benchmarks the whole sequence per sample.
+            b.iter_batched(
+                || {
+                    // Setup for each sample
+                    let fresh_temp_dir = TempDir::new().unwrap();
+                    let mut fresh_db = DB::open(fresh_temp_dir.path(), opts.clone()).unwrap();
+
+                    for (key, value) in &kvs_initial {
+                        fresh_db.put(key, value).unwrap();
+                    }
+                    fresh_db.flush().unwrap();
+
+                    let snapshot = fresh_db.get_snapshot();
+
+                    fresh_db.put(&extra_key, &extra_val).unwrap();
+                    if !kvs_initial.is_empty() {
+                        // Avoid panic on empty kvs_initial
+                        fresh_db.delete(&kvs_initial[0].0).unwrap();
+                    }
+                    fresh_db.flush().unwrap();
+
+                    let idx = rng_bench_iter.gen_range(0..kvs_initial.len());
+                    let key_to_get_from_snapshot = kvs_initial[idx].0.clone();
+
+                    // Return mutable DB, snapshot, key, and temp_dir.
+                    // The DB needs to be mutable if get_at requires &mut DB, otherwise &DB.
+                    // rusty_leveldb::DB::get_at takes &self.
+                    (fresh_db, snapshot, key_to_get_from_snapshot, fresh_temp_dir)
+                },
+                |(mut db_instance, snapshot_instance, key, _temp_dir_to_drop)| {
+                    // Routine
+                    // Use db_instance and snapshot_instance
+                    assert!(db_instance
+                        .get_at(&snapshot_instance, black_box(&key))
+                        .unwrap()
+                        .is_some());
+                    // _temp_dir_to_drop is dropped here
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn db_compact_range_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DB_CompactRange");
+    let key_len = 16;
+    let val_len = 100;
+    let num_items = 10_000;
+
+    for &comp_id in [
+        compressor::NoneCompressor::ID,
+        compressor::SnappyCompressor::ID,
+    ]
+    .iter()
+    {
+        let comp_name = if comp_id == compressor::NoneCompressor::ID {
+            "None"
+        } else {
+            "Snappy"
+        };
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(comp_name),
+            &comp_id,
+            |b, &ci| {
+                let mut opts = get_default_options();
+                opts.compressor = ci;
+                // To make compaction more impactful, you might want to tune these,
+                // but for now, we use defaults.
+                // opts.write_buffer_size = 64 * 1024;
+                // opts.max_file_size = 256 * 1024;
+
+                let mut rng_data_gen = StdRng::seed_from_u64(42);
+                let mut kvs: Vec<(Vec<u8>, Vec<u8>)> = (0..num_items)
+                    .map(|_| generate_kv(key_len, val_len, &mut rng_data_gen))
+                    .collect();
+                kvs.sort_by(|a, b| a.0.cmp(&b.0)); // Sort for defined first/last keys
+
+                // Clone keys for use in the routine, as kvs might be dropped if not careful with lifetimes.
+                let first_key_clone = kvs.first().map(|kv| kv.0.clone());
+                let last_key_clone = kvs.last().map(|kv| kv.0.clone());
+
+                // iter_batched_ref creates a fresh DB, populates, then compacts.
+                // This benchmarks "create + populate + compact" per sample.
+                b.iter_batched_ref(
+                    || {
+                        // Setup for each sample
+                        let fresh_temp_dir = TempDir::new().unwrap();
+                        // Create DB with potentially modified opts if needed for compaction specific tests
+                        let mut fresh_db_opts = opts.clone();
+                        // Example: fresh_db_opts.max_open_files = 50; // to stress compaction
+                        let mut fresh_db = DB::open(fresh_temp_dir.path(), fresh_db_opts).unwrap();
+
+                        for (key, value) in &kvs {
+                            fresh_db.put(key, value).unwrap();
+                        }
+                        // Create some "deletable" space
+                        for i in 0..(num_items / 10) {
+                            if i * 10 < kvs.len() {
+                                // Ensure index is within bounds
+                                fresh_db.delete(&kvs[i * 10].0).unwrap();
+                            }
+                        }
+                        fresh_db.flush().unwrap();
+                        (fresh_db, fresh_temp_dir) // Pass DB and temp_dir
+                    },
+                    |(db_ref, _temp_dir_to_drop)| {
+                        // Routine (takes &mut (DB, TempDir))
+                        if let (Some(f_key), Some(l_key)) =
+                            (first_key_clone.as_ref(), last_key_clone.as_ref())
+                        {
+                            // db_ref is &mut DB from the tuple (fresh_db, fresh_temp_dir)
+                            db_ref
+                                .compact_range(black_box(f_key), black_box(l_key))
+                                .unwrap();
+                        }
+                        // _temp_dir_to_drop is dropped here
+                    },
+                    BatchSize::SmallInput, // Compaction is a single, potentially long operation
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+// --- Tokio AsyncDB Benchmarks ---
+
+#[cfg(feature = "asyncdb-tokio")]
+fn async_db_put_tokio_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("AsyncDB_Tokio_Put");
+    let key_len = 16;
+    let val_len = 100;
+
+    for &comp_id in [
+        compressor::NoneCompressor::ID,
+        compressor::SnappyCompressor::ID,
+    ]
+    .iter()
+    {
+        let comp_name = if comp_id == compressor::NoneCompressor::ID {
+            "None"
+        } else {
+            "Snappy"
+        };
+        group.bench_with_input(
+            BenchmarkId::from_parameter(comp_name),
+            &comp_id,
+            |b, &ci| {
+                let rt = Runtime::new().unwrap();
+                let temp_dir = TempDir::new().unwrap(); // One temp_dir for this parameter set
+                let mut opts = get_default_options();
+                opts.compressor = ci;
+                let adb = rt.block_on(async { TokioAsyncDB::new(temp_dir.path(), opts).unwrap() });
+                let mut rng = StdRng::seed_from_u64(123); // Seed for KV generation
+
+                b.iter_batched(
+                    || generate_kv(key_len, val_len, &mut rng),
+                    |kv_pair| {
+                        // kv_pair is (Vec<u8>, Vec<u8>)
+                        rt.block_on(async {
+                            adb.put(black_box(kv_pair.0), black_box(kv_pair.1))
+                                .await
+                                .unwrap();
+                        });
+                    },
+                    BatchSize::SmallInput,
+                );
+
+                rt.block_on(async {
+                    adb.close().await.unwrap();
+                });
+                // temp_dir is dropped here
+            },
+        );
+    }
+    group.finish();
+}
+
+#[cfg(feature = "asyncdb-tokio")]
+fn async_db_get_tokio_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("AsyncDB_Tokio_Get");
+    let key_len = 16;
+    let val_len = 100;
+    let num_items = 1_000; // Fewer items for async get, adjust as needed
+
+    for &comp_id in [
+        compressor::NoneCompressor::ID,
+        compressor::SnappyCompressor::ID,
+    ]
+    .iter()
+    {
+        let comp_name = if comp_id == compressor::NoneCompressor::ID {
+            "None"
+        } else {
+            "Snappy"
+        };
+
+        // Setup common for both "Existing" and "NonExisting" for a given compressor
+        let rt = Runtime::new().unwrap();
+        let temp_dir = TempDir::new().unwrap(); // One temp_dir for this compressor type
+        let mut opts = get_default_options();
+        opts.compressor = comp_id;
+
+        // Pre-generate KVs and populate the DB once per compressor type
+        let mut populate_rng_outer = StdRng::seed_from_u64(42);
+        let kvs_for_setup: Vec<(Vec<u8>, Vec<u8>)> = (0..num_items)
+            .map(|_| generate_kv(key_len, val_len, &mut populate_rng_outer))
+            .collect();
+
+        let adb = rt.block_on(async {
+            let db_instance = TokioAsyncDB::new(temp_dir.path(), opts).unwrap();
+            for (key, value) in &kvs_for_setup {
+                db_instance.put(key.clone(), value.clone()).await.unwrap();
+            }
+            db_instance.flush().await.unwrap();
+            db_instance
+        });
+
+        // Benchmark getting existing keys
+        // Clone kvs_for_setup for use in the benchmark closure
+        let kvs_existing = kvs_for_setup.clone();
+        group.bench_with_input(
+            BenchmarkId::new("Existing", comp_name),
+            &adb, // Pass the initialized adb
+            |b, db_ref| {
+                // db_ref is &TokioAsyncDB
+                let mut rng_select_key = StdRng::seed_from_u64(234);
+                b.iter_batched(
+                    || {
+                        // Setup: pick a random key that exists
+                        let idx = rng_select_key.gen_range(0..num_items);
+                        kvs_existing[idx].0.clone() // Clone the key
+                    },
+                    |key_to_get| {
+                        // Routine: get the key
+                        rt.block_on(async {
+                            assert!(db_ref.get(black_box(key_to_get)).await.unwrap().is_some());
+                        });
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        // Benchmark getting non-existing keys
+        let mut non_existing_rng = StdRng::seed_from_u64(345);
+        let non_existing_key = generate_kv(key_len, val_len, &mut non_existing_rng).0;
+        group.bench_with_input(
+            BenchmarkId::new("NonExisting", comp_name),
+            &adb, // Pass the same initialized adb
+            |b, db_ref| {
+                // For non-existing, the key is fixed, so iter_batched's setup is trivial (just cloning the key)
+                b.iter_batched(
+                    || non_existing_key.clone(),
+                    |key_to_get| {
+                        rt.block_on(async {
+                            assert!(db_ref.get(black_box(key_to_get)).await.unwrap().is_none());
+                        });
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        // Close DB after both benchmarks for this compressor type are done
+        rt.block_on(async {
+            adb.close().await.unwrap();
+        });
+        // temp_dir is dropped here
+    }
+    group.finish();
+}
+
+// --- Async-std AsyncDB Benchmarks ---
+
+#[cfg(feature = "asyncdb-async-std")]
+fn async_db_put_async_std_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("AsyncDB_AsyncStd_Put");
+    let key_len = 16;
+    let val_len = 100;
+
+    for &comp_id in [
+        compressor::NoneCompressor::ID,
+        compressor::SnappyCompressor::ID,
+    ]
+    .iter()
+    {
+        let comp_name = if comp_id == compressor::NoneCompressor::ID {
+            "None"
+        } else {
+            "Snappy"
+        };
+        group.bench_with_input(
+            BenchmarkId::from_parameter(comp_name),
+            &comp_id,
+            |b, &ci| {
+                let temp_dir = TempDir::new().unwrap();
+                let mut opts = get_default_options();
+                opts.compressor = ci;
+                // AsyncStdAsyncDB::new is not async, so no block_on needed here.
+                let adb = AsyncStdAsyncDB::new(temp_dir.path(), opts).unwrap();
+                let mut rng = StdRng::seed_from_u64(123);
+
+                b.iter_batched(
+                    || generate_kv(key_len, val_len, &mut rng),
+                    |kv_pair| {
+                        async_std_task::block_on(async {
+                            adb.put(black_box(kv_pair.0), black_box(kv_pair.1))
+                                .await
+                                .unwrap();
+                        })
+                    },
+                    BatchSize::SmallInput,
+                );
+                async_std_task::block_on(async {
+                    adb.close().await.unwrap();
+                });
+                // temp_dir dropped
+            },
+        );
+    }
+    group.finish();
+}
+
+#[cfg(feature = "asyncdb-async-std")]
+fn async_db_get_async_std_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("AsyncDB_AsyncStd_Get");
+    let key_len = 16;
+    let val_len = 100;
+    let num_items = 1_000;
+
+    for &comp_id in [
+        compressor::NoneCompressor::ID,
+        compressor::SnappyCompressor::ID,
+    ]
+    .iter()
+    {
+        let comp_name = if comp_id == compressor::NoneCompressor::ID {
+            "None"
+        } else {
+            "Snappy"
+        };
+
+        let temp_dir = TempDir::new().unwrap();
+        let mut opts = get_default_options();
+        opts.compressor = comp_id;
+
+        let mut populate_rng_outer = StdRng::seed_from_u64(42);
+        let kvs_for_setup: Vec<(Vec<u8>, Vec<u8>)> = (0..num_items)
+            .map(|_| generate_kv(key_len, val_len, &mut populate_rng_outer))
+            .collect();
+
+        // AsyncStdAsyncDB::new is not async. Populate within block_on.
+        let adb = async_std_task::block_on(async {
+            let db_instance = AsyncStdAsyncDB::new(temp_dir.path(), opts).unwrap();
+            for (key, value) in &kvs_for_setup {
+                db_instance.put(key.clone(), value.clone()).await.unwrap();
+            }
+            db_instance.flush().await.unwrap();
+            db_instance
+        });
+
+        let kvs_existing = kvs_for_setup.clone();
+        group.bench_with_input(
+            BenchmarkId::new("Existing", comp_name),
+            &adb,
+            |b, db_ref| {
+                let mut rng_select_key = StdRng::seed_from_u64(234);
+                b.iter_batched(
+                    || {
+                        let idx = rng_select_key.gen_range(0..num_items);
+                        kvs_existing[idx].0.clone()
+                    },
+                    |key_to_get| {
+                        async_std_task::block_on(async {
+                            assert!(db_ref.get(black_box(key_to_get)).await.unwrap().is_some());
+                        });
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        let mut non_existing_rng = StdRng::seed_from_u64(345);
+        let non_existing_key = generate_kv(key_len, val_len, &mut non_existing_rng).0;
+        group.bench_with_input(
+            BenchmarkId::new("NonExisting", comp_name),
+            &adb,
+            |b, db_ref| {
+                b.iter_batched(
+                    || non_existing_key.clone(),
+                    |key_to_get| {
+                        async_std_task::block_on(async {
+                            assert!(db_ref.get(black_box(key_to_get)).await.unwrap().is_none());
+                        });
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+        async_std_task::block_on(async {
+            adb.close().await.unwrap();
+        });
+        // temp_dir dropped
+    }
+    group.finish();
+}
+
+// --- Criterion Group Definitions ---
+
+criterion_group!(
+    name = benches_db_sync;
+    // Default config, specific groups will override measurement_time if needed
+    config = Criterion::default();
+    targets =
+        db_put_benchmark,
+        db_get_benchmark,
+        db_delete_benchmark,
+        db_write_batch_benchmark,
+        db_iteration_benchmark,
+        db_snapshot_get_benchmark,
+        db_compact_range_benchmark
+);
+
+#[cfg(feature = "asyncdb-tokio")]
+criterion_group!(
+    name = benches_db_async_tokio;
+    config = Criterion::default();
+    targets = async_db_put_tokio_benchmark, async_db_get_tokio_benchmark
+);
+
+#[cfg(feature = "asyncdb-async-std")]
+criterion_group!(
+    name = benches_db_async_std;
+    config = Criterion::default();
+    targets = async_db_put_async_std_benchmark, async_db_get_async_std_benchmark
+);
+
+// --- Criterion Main ---
+#[cfg(all(not(feature = "asyncdb-tokio"), not(feature = "asyncdb-async-std")))]
+criterion_main!(benches_db_sync);
+
+#[cfg(all(feature = "asyncdb-tokio", not(feature = "asyncdb-async-std")))]
+criterion_main!(benches_db_sync, benches_db_async_tokio);
+
+#[cfg(all(not(feature = "asyncdb-tokio"), feature = "asyncdb-async-std"))]
+criterion_main!(benches_db_sync, benches_db_async_std);
+
+#[cfg(all(feature = "asyncdb-tokio", feature = "asyncdb-async-std"))]
+criterion_main!(
+    benches_db_sync,
+    benches_db_async_tokio,
+    benches_db_async_std
+);

--- a/src/block.rs
+++ b/src/block.rs
@@ -7,8 +7,9 @@ use crate::types::LdbIterator;
 
 use integer_encoding::FixedInt;
 use integer_encoding::VarInt;
+use bytes::Bytes;
 
-pub type BlockContents = Vec<u8>;
+pub type BlockContents = Bytes;
 
 /// A Block is an immutable ordered set of key/value entries.
 ///

--- a/src/block.rs
+++ b/src/block.rs
@@ -5,9 +5,9 @@ use std::rc::Rc;
 use crate::options::Options;
 use crate::types::LdbIterator;
 
+use bytes::Bytes;
 use integer_encoding::FixedInt;
 use integer_encoding::VarInt;
-use bytes::Bytes;
 
 pub type BlockContents = Bytes;
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,7 +1,5 @@
 use std::cmp::Ordering;
 
-use std::rc::Rc;
-
 use crate::options::Options;
 use crate::types::LdbIterator;
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -33,7 +33,7 @@ pub type BlockContents = Bytes;
 /// N_RESTARTS contains the number of restarts.
 #[derive(Clone)]
 pub struct Block {
-    block: Rc<BlockContents>,
+    block: BlockContents,
     opt: Options,
 }
 
@@ -60,14 +60,14 @@ impl Block {
         }
     }
 
-    pub fn contents(&self) -> Rc<BlockContents> {
+    pub fn contents(&self) -> BlockContents {
         self.block.clone()
     }
 
     pub fn new(opt: Options, contents: BlockContents) -> Block {
         assert!(contents.len() > 4);
         Block {
-            block: Rc::new(contents),
+            block: contents,
             opt,
         }
     }
@@ -78,7 +78,7 @@ impl Block {
 pub struct BlockIter {
     /// The underlying block contents.
     /// TODO: Maybe (probably...) this needs an Arc.
-    block: Rc<BlockContents>,
+    block: BlockContents,
     opt: Options,
     /// offset of restarts area within the block.
     restarts_off: usize,

--- a/src/block.rs
+++ b/src/block.rs
@@ -297,15 +297,14 @@ impl LdbIterator for BlockIter {
         !self.key.is_empty() && self.val_offset > 0 && self.val_offset <= self.restarts_off
     }
 
-    fn current(&self, key: &mut Vec<u8>, val: &mut Vec<u8>) -> bool {
+    fn current(&self) -> Option<(Bytes, Bytes)> {
         if self.valid() {
-            key.clear();
-            val.clear();
-            key.extend_from_slice(&self.key);
-            val.extend_from_slice(&self.block[self.val_offset..self.offset]);
-            true
+            Some((
+                Bytes::copy_from_slice(&self.key),
+                Bytes::copy_from_slice(&self.block[self.val_offset..self.offset]),
+            ))
         } else {
-            false
+            None
         }
     }
 }

--- a/src/block_builder.rs
+++ b/src/block_builder.rs
@@ -115,7 +115,7 @@ impl BlockBuilder {
             .expect("write to buffer failed");
 
         // done
-        self.buffer
+        self.buffer.into()
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -215,7 +215,7 @@ impl<T> Cache<T> {
         match self.map.get(key) {
             None => None,
             Some((elem, lru_handle)) => {
-                self.list.reinsert_front(&lru_handle);
+                self.list.reinsert_front(lru_handle);
                 Some(elem)
             }
         }

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -1,11 +1,25 @@
-const CRC: crc::Crc<u32, crc::Table<1>> = crc::Crc::<u32, crc::Table<1>>::new(&crc::CRC_32_ISCSI);
-
 pub(crate) fn crc32(data: impl AsRef<[u8]>) -> u32 {
-    let mut digest = CRC.digest();
-    digest.update(data.as_ref());
-    digest.finalize()
+    crc32c::crc32c(data.as_ref())
 }
 
-pub(crate) fn digest() -> crc::Digest<'static, u32> {
-    CRC.digest()
+pub(crate) struct Digest {
+    hasher: crc32c::Crc32cHasher,
+}
+
+impl Digest {
+    pub fn update(&mut self, data: &[u8]) {
+        use std::hash::Hasher;
+        self.hasher.write(data);
+    }
+
+    pub fn finalize(self) -> u32 {
+        use std::hash::Hasher;
+        self.hasher.finish() as u32
+    }
+}
+
+pub(crate) fn digest() -> Digest {
+    Digest {
+        hasher: crc32c::Crc32cHasher::new(0),
+    }
 }

--- a/src/db_impl.rs
+++ b/src/db_impl.rs
@@ -1531,7 +1531,7 @@ mod tests {
         assert!(db.get_at(&old_ss, b"xyz").unwrap().is_none());
 
         // memtable get
-        assert_eq!(b"123", &*db.get(b"xyz").unwrap());
+        assert_eq!(b"123", db.get(b"xyz").unwrap().as_ref());
         assert!(db.get_internal(31, b"xyy").unwrap().is_some());
         assert!(db.get_internal(32, b"xyy").unwrap().is_some());
 
@@ -1539,17 +1539,17 @@ mod tests {
         assert!(db.get_internal(32, b"xyz").unwrap().is_some());
 
         // table get
-        assert_eq!(b"val2", &*db.get(b"eab").unwrap());
+        assert_eq!(b"val2", db.get(b"eab").unwrap().as_ref());
         assert!(db.get_internal(3, b"eab").unwrap().is_none());
         assert!(db.get_internal(32, b"eab").unwrap().is_some());
 
         {
             let ss = db.get_snapshot();
-            assert_eq!(b"val2", &*db.get_at(&ss, b"eab").unwrap().unwrap());
+            assert_eq!(b"val2", db.get_at(&ss, b"eab").unwrap().unwrap().as_ref());
         }
 
         // from table.
-        assert_eq!(b"val2", &*db.get(b"cab").unwrap());
+        assert_eq!(b"val2", db.get(b"cab").unwrap().as_ref());
     }
 
     #[test]

--- a/src/db_impl.rs
+++ b/src/db_impl.rs
@@ -465,7 +465,7 @@ impl DB {
                 if current.update_stats(st) {
                     do_compaction = true;
                 }
-                result = Some(v.into())
+                result = Some(v)
             }
         }
 
@@ -486,11 +486,7 @@ impl DB {
     /// get is a simplified version of get_at(), translating errors to None.
     pub fn get(&mut self, key: &[u8]) -> Option<Bytes> {
         let seq = self.vset.borrow().last_seq;
-        if let Ok(v) = self.get_internal(seq, key) {
-            v
-        } else {
-            None
-        }
+        self.get_internal(seq, key).unwrap_or_default()
     }
 }
 

--- a/src/db_impl.rs
+++ b/src/db_impl.rs
@@ -30,6 +30,7 @@ use crate::version_set::{
 };
 use crate::write_batch::WriteBatch;
 
+use bytes::Bytes;
 use std::cmp::Ordering;
 use std::io::{self, BufWriter, Write};
 use std::mem;
@@ -37,7 +38,6 @@ use std::ops::Drop;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
-use bytes::Bytes;
 
 /// DB contains the actual database implemenation. As opposed to the original, this implementation
 /// is not concurrent (yet).
@@ -648,7 +648,7 @@ impl DB {
                 if let Some(c) = c_ {
                     // Update ifrom to the largest key of the last file in this compaction.
                     let ix = c.num_inputs(0) - 1;
-                    ifrom.clone_from(&c.input(0, ix).largest);
+                    ifrom.clone_from(&c.input(0, ix).largest.into());
                     self.start_compaction(c)?;
                 } else {
                     break;
@@ -805,7 +805,6 @@ impl DB {
         let mut input = self.vset.borrow().make_input_iterator(&cs.compaction);
         input.seek_to_first();
 
-        let (mut key, mut val);
         let mut last_seq_for_key = MAX_SEQUENCE_NUMBER;
 
         let mut have_ukey = false;
@@ -814,19 +813,15 @@ impl DB {
         while input.valid() {
             // TODO: Do we need to do a memtable compaction here? Probably not, in the sequential
             // case.
-            if let Some((key_bytes, val_bytes)) = input.current() {
-                key = key_bytes.to_vec();
-                val = val_bytes.to_vec();
-            } else {
-                panic!("Iterator should be valid here");
-            }
-            if cs.compaction.should_stop_before(&key) && cs.builder.is_some() {
+            let (key_bytes, val_bytes) = input.current().expect("Iterator should be valid here");
+
+            if cs.compaction.should_stop_before(&key_bytes) && cs.builder.is_some() {
                 self.finish_compaction_output(cs)?;
             }
-            let (ktyp, seq, ukey) = parse_internal_key(&key);
+            let (ktyp, seq, ukey) = parse_internal_key(&key_bytes);
             if seq == 0 {
                 // Parsing failed.
-                log!(self.opt.log, "Encountered seq=0 in key: {:?}", &key);
+                log!(self.opt.log, "Encountered seq=0 in key: {:?}", &key_bytes);
                 last_seq_for_key = MAX_SEQUENCE_NUMBER;
                 have_ukey = false;
                 current_ukey.clear();
@@ -875,10 +870,10 @@ impl DB {
                 cs.outputs.push(fmd);
             }
             if cs.builder.as_ref().unwrap().entries() == 0 {
-                cs.current_output().smallest.clone_from(&key);
+                cs.current_output().smallest.clone_from(&key_bytes);
             }
-            cs.current_output().largest.clone_from(&key);
-            cs.builder.as_mut().unwrap().add(&key, &val)?;
+            cs.current_output().largest.clone_from(&key_bytes);
+            cs.builder.as_mut().unwrap().add(&key_bytes, &val_bytes)?;
             // NOTE: Adjust max file size based on level.
             if cs.builder.as_ref().unwrap().size_estimate() > self.opt.max_file_size {
                 self.finish_compaction_output(cs)?;
@@ -1066,8 +1061,8 @@ pub fn build_table<I: LdbIterator, P: AsRef<Path>>(
         Some(key) => {
             md.num = num;
             md.size = opt.env.size_of(Path::new(&filename))?;
-            md.smallest = key;
-            md.largest = kbuf;
+            md.smallest = key.into();
+            md.largest = kbuf.into();
         }
     }
     Ok(md)
@@ -1331,10 +1326,7 @@ mod tests {
             assert!(!env.exists(&Path::new("db").join("000006.log")).unwrap());
             // Log is reused, so memtable should contain last written entry from above.
             assert_eq!(1, db.mem.len());
-            assert_eq!(
-                b"def",
-                &*db.mem.get(&LookupKey::new(b"abe", 3)).0.unwrap()
-            );
+            assert_eq!(b"def", &*db.mem.get(&LookupKey::new(b"abe", 3)).0.unwrap());
         }
     }
 
@@ -1477,14 +1469,8 @@ mod tests {
         let f = build_table("db", &opt, mt.iter(), 123).unwrap();
         let path = &Path::new("db").join("000123.ldb");
 
-        assert_eq!(
-            LookupKey::new(b"aabc", 6).internal_key(),
-            &f.smallest
-        );
-        assert_eq!(
-            LookupKey::new(b"test123", 7).internal_key(),
-            &f.largest
-        );
+        assert_eq!(LookupKey::new(b"aabc", 6).internal_key(), &f.smallest);
+        assert_eq!(LookupKey::new(b"test123", 7).internal_key(), &f.largest);
         assert_eq!(379, f.size);
         assert_eq!(123, f.num);
         assert!(opt.env.exists(path).unwrap());
@@ -1789,20 +1775,35 @@ mod tests {
             db.put(b"xx4", b"222").unwrap();
             let ss2 = db.get_snapshot();
 
-            assert_eq!(Some(b"113".to_vec()), db.get_at(&ss, b"xx3").unwrap().map(|b| b.to_vec()));
+            assert_eq!(
+                Some(b"113".to_vec()),
+                db.get_at(&ss, b"xx3").unwrap().map(|b| b.to_vec())
+            );
             assert_eq!(None, db.get_at(&ss, b"xx2").unwrap());
             assert_eq!(None, db.get_at(&ss, b"xx5").unwrap());
 
-            assert_eq!(Some(b"114".to_vec()), db.get_at(&ss, b"xx4").unwrap().map(|b| b.to_vec()));
-            assert_eq!(Some(b"222".to_vec()), db.get_at(&ss2, b"xx4").unwrap().map(|b| b.to_vec()));
+            assert_eq!(
+                Some(b"114".to_vec()),
+                db.get_at(&ss, b"xx4").unwrap().map(|b| b.to_vec())
+            );
+            assert_eq!(
+                Some(b"222".to_vec()),
+                db.get_at(&ss2, b"xx4").unwrap().map(|b| b.to_vec())
+            );
         }
 
         {
             let mut db = DB::open("db", opt).unwrap();
 
             let ss = db.get_snapshot();
-            assert_eq!(Some(b"113".to_vec()), db.get_at(&ss, b"xx3").unwrap().map(|b| b.to_vec()));
-            assert_eq!(Some(b"222".to_vec()), db.get_at(&ss, b"xx4").unwrap().map(|b| b.to_vec()));
+            assert_eq!(
+                Some(b"113".to_vec()),
+                db.get_at(&ss, b"xx3").unwrap().map(|b| b.to_vec())
+            );
+            assert_eq!(
+                Some(b"222".to_vec()),
+                db.get_at(&ss, b"xx4").unwrap().map(|b| b.to_vec())
+            );
             assert_eq!(None, db.get_at(&ss, b"xx2").unwrap());
         }
     }

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -5,10 +5,10 @@ use crate::snapshot::Snapshot;
 use crate::types::{Direction, LdbIterator, Shared};
 use crate::version_set::VersionSet;
 
+use bytes::Bytes;
 use std::cmp::Ordering;
 use std::mem;
 use std::rc::Rc;
-use bytes::Bytes;
 
 const READ_BYTES_PERIOD: isize = 1048576;
 
@@ -215,7 +215,10 @@ impl LdbIterator for DBIterator {
                 None
             }
         } else {
-            Some((Bytes::copy_from_slice(&self.savedkey), Bytes::copy_from_slice(&self.savedval)))
+            Some((
+                Bytes::copy_from_slice(&self.savedkey),
+                Bytes::copy_from_slice(&self.savedval),
+            ))
         }
     }
     fn prev(&mut self) -> bool {

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -332,7 +332,7 @@ mod tests {
         for (k, v) in keys.iter().zip(vals.iter()) {
             assert!(iter.advance());
             assert_eq!((k.to_vec(), v.to_vec()), current_key_val(&iter).unwrap());
-            let entry = db.get(*k).expect("key returned by iterator is in database");
+            let entry = db.get(k).expect("key returned by iterator is in database");
             assert_eq!(v.to_vec(), entry);
             found.push((k.to_vec(), v.to_vec()));
         }

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -8,6 +8,7 @@ use crate::version_set::VersionSet;
 use std::cmp::Ordering;
 use std::mem;
 use std::rc::Rc;
+use bytes::Bytes;
 
 const READ_BYTES_PERIOD: isize = 1048576;
 
@@ -74,25 +75,28 @@ impl DBIterator {
         assert!(self.dir == Direction::Forward);
 
         while self.iter.valid() {
-            self.iter.current(&mut self.keybuf, &mut self.savedval);
-            let len = self.keybuf.len() + self.savedval.len();
-            self.record_read_sample(len);
-            let (typ, seq, ukey) = parse_internal_key(&self.keybuf);
+            if let Some((key_bytes, val_bytes)) = self.iter.current() {
+                self.keybuf = key_bytes.to_vec();
+                self.savedval = val_bytes.to_vec();
+                let len = self.keybuf.len() + self.savedval.len();
+                self.record_read_sample(len);
+                let (typ, seq, ukey) = parse_internal_key(&self.keybuf);
 
-            // Skip keys with a sequence number after our snapshot.
-            if seq <= self.ss.sequence() {
-                if typ == ValueType::TypeDeletion {
-                    // Mark current (deleted) key to be skipped.
-                    self.savedkey.clear();
-                    self.savedkey.extend_from_slice(ukey);
-                    skipping = true;
-                } else if typ == ValueType::TypeValue {
-                    if skipping && self.cmp.cmp(ukey, &self.savedkey) <= Ordering::Equal {
-                        // Entry hidden, because it's smaller than the key to be skipped.
-                    } else {
-                        self.valid = true;
+                // Skip keys with a sequence number after our snapshot.
+                if seq <= self.ss.sequence() {
+                    if typ == ValueType::TypeDeletion {
+                        // Mark current (deleted) key to be skipped.
                         self.savedkey.clear();
-                        return true;
+                        self.savedkey.extend_from_slice(ukey);
+                        skipping = true;
+                    } else if typ == ValueType::TypeValue {
+                        if skipping && self.cmp.cmp(ukey, &self.savedkey) <= Ordering::Equal {
+                            // Entry hidden, because it's smaller than the key to be skipped.
+                        } else {
+                            self.valid = true;
+                            self.savedkey.clear();
+                            return true;
+                        }
                     }
                 }
             }
@@ -122,27 +126,30 @@ impl DBIterator {
         // then break. The key and value of the latest entry for the desired key have been stored
         // in the previous iteration to savedkey and savedval.
         while self.iter.valid() {
-            self.iter.current(&mut self.keybuf, &mut self.valbuf);
-            let len = self.keybuf.len() + self.valbuf.len();
-            self.record_read_sample(len);
-            let (typ, seq, ukey) = parse_internal_key(&self.keybuf);
+            if let Some((key_bytes, val_bytes)) = self.iter.current() {
+                self.keybuf = key_bytes.to_vec();
+                self.valbuf = val_bytes.to_vec();
+                let len = self.keybuf.len() + self.valbuf.len();
+                self.record_read_sample(len);
+                let (typ, seq, ukey) = parse_internal_key(&self.keybuf);
 
-            if seq > 0 && seq <= self.ss.sequence() {
-                if value_type != ValueType::TypeDeletion
-                    && self.cmp.cmp(ukey, &self.savedkey) == Ordering::Less
-                {
-                    // We found a non-deleted entry for a previous key (in the previous iteration)
-                    break;
-                }
-                value_type = typ;
-                if value_type == ValueType::TypeDeletion {
-                    self.savedkey.clear();
-                    self.savedval.clear();
-                } else {
-                    self.savedkey.clear();
-                    self.savedkey.extend_from_slice(ukey);
+                if seq > 0 && seq <= self.ss.sequence() {
+                    if value_type != ValueType::TypeDeletion
+                        && self.cmp.cmp(ukey, &self.savedkey) == Ordering::Less
+                    {
+                        // We found a non-deleted entry for a previous key (in the previous iteration)
+                        break;
+                    }
+                    value_type = typ;
+                    if value_type == ValueType::TypeDeletion {
+                        self.savedkey.clear();
+                        self.savedval.clear();
+                    } else {
+                        self.savedkey.clear();
+                        self.savedkey.extend_from_slice(ukey);
 
-                    mem::swap(&mut self.savedval, &mut self.valbuf);
+                        mem::swap(&mut self.savedval, &mut self.valbuf);
+                    }
                 }
             }
             self.iter.prev();
@@ -181,29 +188,34 @@ impl LdbIterator for DBIterator {
             }
         } else {
             // Save current user key.
-            assert!(self.iter.current(&mut self.savedkey, &mut self.savedval));
-            truncate_to_userkey(&mut self.savedkey);
+            if let Some((key_bytes, val_bytes)) = self.iter.current() {
+                self.savedkey = key_bytes.to_vec();
+                self.savedval = val_bytes.to_vec();
+                truncate_to_userkey(&mut self.savedkey);
+            } else {
+                panic!("Iterator should be valid here");
+            }
         }
         self.find_next_user_entry(
             // skipping=
             true,
         )
     }
-    fn current(&self, key: &mut Vec<u8>, val: &mut Vec<u8>) -> bool {
+    fn current(&self) -> Option<(Bytes, Bytes)> {
         if !self.valid() {
-            return false;
+            return None;
         }
         // If direction is forward, savedkey and savedval are not used.
         if self.dir == Direction::Forward {
-            self.iter.current(key, val);
-            truncate_to_userkey(key);
-            true
+            if let Some((key_bytes, val_bytes)) = self.iter.current() {
+                let mut key = key_bytes.to_vec();
+                truncate_to_userkey(&mut key);
+                Some((Bytes::from(key), val_bytes))
+            } else {
+                None
+            }
         } else {
-            key.clear();
-            key.extend_from_slice(&self.savedkey);
-            val.clear();
-            val.extend_from_slice(&self.savedval);
-            true
+            Some((Bytes::copy_from_slice(&self.savedkey), Bytes::copy_from_slice(&self.savedval)))
         }
     }
     fn prev(&mut self) -> bool {
@@ -216,8 +228,11 @@ impl LdbIterator for DBIterator {
             // find_prev_user_entry() wants savedkey to be the key of the entry that is supposed to
             // be left in savedkey/savedval, which is why we have to go to the previous entry before
             // calling it.
-            self.iter.current(&mut self.savedkey, &mut self.savedval);
-            truncate_to_userkey(&mut self.savedkey);
+            if let Some((key_bytes, val_bytes)) = self.iter.current() {
+                self.savedkey = key_bytes.to_vec();
+                self.savedval = val_bytes.to_vec();
+                truncate_to_userkey(&mut self.savedkey);
+            }
             loop {
                 self.iter.prev();
                 if !self.iter.valid() {
@@ -227,8 +242,10 @@ impl LdbIterator for DBIterator {
                     return false;
                 }
                 // Scan until we hit the next-smaller key.
-                self.iter.current(&mut self.keybuf, &mut self.savedval);
-                truncate_to_userkey(&mut self.keybuf);
+                if let Some((key_bytes, _val_bytes)) = self.iter.current() {
+                    self.keybuf = key_bytes.to_vec();
+                    truncate_to_userkey(&mut self.keybuf);
+                }
                 if self.cmp.cmp(&self.keybuf, &self.savedkey) == Ordering::Less {
                     break;
                 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -139,7 +139,7 @@ impl FilterPolicy for BloomPolicy {
         // Add all keys to the filter.
         offset_data_iterate(keys, key_offsets, |key| {
             let mut h = self.bloom_hash(key);
-            let delta = (h >> 17) | (h << 15);
+            let delta = h.rotate_left(15);
             for _ in 0..self.k {
                 let bitpos = (h % adj_filter_bits) as usize;
                 filter[bitpos / 8] |= 1 << (bitpos % 8);
@@ -163,7 +163,7 @@ impl FilterPolicy for BloomPolicy {
         }
 
         let mut h = self.bloom_hash(key);
-        let delta = (h >> 17) | (h << 15);
+        let delta = h.rotate_left(15);
         for _ in 0..k {
             let bitpos = (h % bits) as usize;
             if (filter_adj[bitpos / 8] & (1 << (bitpos % 8))) == 0 {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -139,7 +139,7 @@ impl FilterPolicy for BloomPolicy {
         // Add all keys to the filter.
         offset_data_iterate(keys, key_offsets, |key| {
             let mut h = self.bloom_hash(key);
-            let delta = h.rotate_left(15);
+            let delta = (h >> 17) | (h << 15);
             for _ in 0..self.k {
                 let bitpos = (h % adj_filter_bits) as usize;
                 filter[bitpos / 8] |= 1 << (bitpos % 8);
@@ -163,7 +163,7 @@ impl FilterPolicy for BloomPolicy {
         }
 
         let mut h = self.bloom_hash(key);
-        let delta = h.rotate_left(15);
+        let delta = (h >> 17) | (h << 15);
         for _ in 0..k {
             let bitpos = (h % bits) as usize;
             if (filter_adj[bitpos / 8] & (1 << (bitpos % 8))) == 0 {

--- a/src/filter_block.rs
+++ b/src/filter_block.rs
@@ -115,10 +115,10 @@ pub struct FilterBlockReader {
 
 impl FilterBlockReader {
     pub fn new_owned(pol: BoxedFilterPolicy, data: Vec<u8>) -> FilterBlockReader {
-        FilterBlockReader::new(pol, Rc::new(data))
+        FilterBlockReader::new(pol, Rc::new(data.into()))
     }
 
-    pub fn new(pol: BoxedFilterPolicy, data: Rc<Vec<u8>>) -> FilterBlockReader {
+    pub fn new(pol: BoxedFilterPolicy, data: Rc<BlockContents>) -> FilterBlockReader {
         assert!(data.len() >= 5);
 
         let fbase = data[data.len() - 1] as u32;

--- a/src/key_types.rs
+++ b/src/key_types.rs
@@ -60,7 +60,7 @@ impl LookupKey {
                 .expect("write to slice failed");
             writer.write_all(k).expect("write to slice failed");
             writer
-                .write_fixedint(s << 8 | t as u64)
+                .write_fixedint((s << 8) | t as u64)
                 .expect("write to slice failed");
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! let mut db = DB::open("mydatabase", opt).unwrap();
 //!
 //! db.put(b"Hello", b"World").unwrap();
-//! assert_eq!(b"World", db.get(b"Hello").unwrap().as_slice());
+//! assert_eq!(b"World", &*db.get(b"Hello").unwrap());
 //!
 //! let mut iter = db.new_iter().unwrap();
 //! // Note: For efficiency reasons, it's recommended to use advance() and current() instead of

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -367,7 +367,7 @@ mod tests {
         let (keylen, keyoff, tag, vallen, valoff) = parse_memtable_key(&key);
         assert_eq!(keylen, 3);
         assert_eq!(&key[keyoff..keyoff + keylen], vec![1, 2, 3].as_slice());
-        assert_eq!(tag, 123 << 8 | 1);
+        assert_eq!(tag, (123 << 8) | 1);
         assert_eq!(vallen, 3);
         assert_eq!(&key[valoff..valoff + vallen], vec![4, 5, 6].as_slice());
     }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -6,8 +6,8 @@ use crate::types::{current_key_val, LdbIterator, SequenceNumber};
 
 use std::rc::Rc;
 
-use integer_encoding::FixedInt;
 use bytes::Bytes;
+use integer_encoding::FixedInt;
 
 /// Provides Insert/Get/Iterate, based on the SkipMap implementation.
 /// MemTable uses MemtableKeys internally, that is, it stores key and value in the [Skipmap] key.
@@ -56,7 +56,10 @@ impl MemTable {
             // We only care about user key equality here
             if key.user_key() == &foundkey[fkeyoff..fkeyoff + fkeylen] {
                 if tag & 0xff == ValueType::TypeValue as u64 {
-                    return (Some(foundkey[valoff..valoff + vallen].to_vec().into()), false);
+                    return (
+                        Some(foundkey[valoff..valoff + vallen].to_vec().into()),
+                        false,
+                    );
                 } else {
                     return (None, true);
                 }
@@ -121,7 +124,8 @@ impl LdbIterator for MemtableIterator {
 
         if let Some((key_bytes, _val_bytes)) = self.skipmapiter.current() {
             let (keylen, keyoff, _, vallen, valoff) = parse_memtable_key(&key_bytes);
-            let internal_key = Bytes::copy_from_slice(&key_bytes[keyoff..keyoff + keylen + u64::required_space()]);
+            let internal_key =
+                Bytes::copy_from_slice(&key_bytes[keyoff..keyoff + keylen + u64::required_space()]);
             let value = Bytes::copy_from_slice(&key_bytes[valoff..valoff + vallen]);
             Some((internal_key, value))
         } else {

--- a/src/merging_iter.rs
+++ b/src/merging_iter.rs
@@ -1,9 +1,9 @@
 use crate::cmp::Cmp;
 use crate::types::{current_key_val, Direction, LdbIterator};
 
+use bytes::Bytes;
 use std::cmp::Ordering;
 use std::rc::Rc;
-use bytes::Bytes;
 
 // Warning: This module is kinda messy. The original implementation is
 // not that much better though :-)

--- a/src/merging_iter.rs
+++ b/src/merging_iter.rs
@@ -3,6 +3,7 @@ use crate::types::{current_key_val, Direction, LdbIterator};
 
 use std::cmp::Ordering;
 use std::rc::Rc;
+use bytes::Bytes;
 
 // Warning: This module is kinda messy. The original implementation is
 // not that much better though :-)
@@ -53,9 +54,6 @@ impl MergingIter {
             return;
         }
 
-        let mut keybuf = vec![];
-        let mut valbuf = vec![];
-
         if let Some((key, _)) = current_key_val(self) {
             if let Some(current) = self.current {
                 match d {
@@ -67,10 +65,10 @@ impl MergingIter {
                                 // This doesn't work if two iterators are returning the exact same
                                 // keys. However, in reality, two entries will always have differing
                                 // sequence numbers.
-                                if self.iters[i].current(&mut keybuf, &mut valbuf)
-                                    && self.cmp.cmp(&keybuf, &key) == Ordering::Equal
-                                {
-                                    self.iters[i].advance();
+                                if let Some((current_key, _)) = self.iters[i].current() {
+                                    if self.cmp.cmp(&current_key, &key) == Ordering::Equal {
+                                        self.iters[i].advance();
+                                    }
                                 }
                             }
                         }
@@ -115,12 +113,11 @@ impl MergingIter {
         };
 
         let mut next_ix = 0;
-        let (mut current, mut smallest, mut valscratch) = (vec![], vec![], vec![]);
 
         for i in 1..self.iters.len() {
-            if self.iters[i].current(&mut current, &mut valscratch) {
-                if self.iters[next_ix].current(&mut smallest, &mut valscratch) {
-                    if self.cmp.cmp(&current, &smallest) == ord {
+            if let Some((current_key, _)) = self.iters[i].current() {
+                if let Some((smallest_key, _)) = self.iters[next_ix].current() {
+                    if self.cmp.cmp(&current_key, &smallest_key) == ord {
                         next_ix = i;
                     }
                 } else {
@@ -168,11 +165,11 @@ impl LdbIterator for MergingIter {
         }
         self.current = None;
     }
-    fn current(&self, key: &mut Vec<u8>, val: &mut Vec<u8>) -> bool {
+    fn current(&self) -> Option<(Bytes, Bytes)> {
         if let Some(ix) = self.current {
-            self.iters[ix].current(key, val)
+            self.iters[ix].current()
         } else {
-            false
+            None
         }
     }
     fn prev(&mut self) -> bool {

--- a/src/skipmap.rs
+++ b/src/skipmap.rs
@@ -3,11 +3,11 @@ use crate::rand::rngs::StdRng;
 use crate::rand::{RngCore, SeedableRng};
 use crate::types::LdbIterator;
 
+use bytes::Bytes;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::mem::{replace, size_of};
 use std::rc::Rc;
-use bytes::Bytes;
 
 const MAX_HEIGHT: usize = 12;
 const BRANCHING_FACTOR: u32 = 4;
@@ -434,36 +434,20 @@ pub mod tests {
             b"aba"
         );
         assert_eq!(
-            &*skm.map
-                .borrow()
-                .get_greater_or_equal(b"ab")
-                .unwrap()
-                .key,
+            &*skm.map.borrow().get_greater_or_equal(b"ab").unwrap().key,
             b"aba"
         );
         assert_eq!(
-            &*skm.map
-                .borrow()
-                .get_greater_or_equal(b"abc")
-                .unwrap()
-                .key,
+            &*skm.map.borrow().get_greater_or_equal(b"abc").unwrap().key,
             b"abc"
         );
         assert!(skm.map.borrow().get_next_smaller(b"ab0").is_none());
         assert_eq!(
-            &*skm.map
-                .borrow()
-                .get_next_smaller(b"abd")
-                .unwrap()
-                .key,
+            &*skm.map.borrow().get_next_smaller(b"abd").unwrap().key,
             b"abc"
         );
         assert_eq!(
-            &*skm.map
-                .borrow()
-                .get_next_smaller(b"ab{")
-                .unwrap()
-                .key,
+            &*skm.map.borrow().get_next_smaller(b"ab{").unwrap().key,
             b"abz"
         );
     }

--- a/src/table_block.rs
+++ b/src/table_block.rs
@@ -73,7 +73,7 @@ pub fn read_table_block(
 
     Ok(Block::new(
         opt,
-        compressor_list.get(compress[0])?.decode(buf)?,
+        compressor_list.get(compress[0])?.decode(buf)?.into(),
     ))
 }
 

--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -206,7 +206,7 @@ impl<Dst: Write> TableBuilder<Dst> {
         compressor_id_pair: (u8, &dyn Compressor),
     ) -> Result<BlockHandle> {
         let (ctype, compressor) = compressor_id_pair;
-        let data = compressor.encode(block)?;
+        let data = compressor.encode(block.to_vec())?;
 
         let mut digest = crc::digest();
 
@@ -251,7 +251,7 @@ impl<Dst: Write> TableBuilder<Dst> {
             let filter_key = format!("filter.{}", fblock.filter_name());
             let fblock_data = fblock.finish();
             let fblock_handle = self.write_block(
-                fblock_data,
+                fblock_data.into(),
                 (compressor::NoneCompressor::ID, &compressor::NoneCompressor),
             )?;
 

--- a/src/table_cache.rs
+++ b/src/table_cache.rs
@@ -12,10 +12,10 @@ use crate::types::{FileNum, Shared};
 
 use integer_encoding::FixedIntWriter;
 
+use bytes::Bytes;
 use std::convert::AsRef;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
-use bytes::Bytes;
 
 pub fn table_file_name<P: AsRef<Path>>(name: P, num: FileNum) -> PathBuf {
     assert!(num > 0);
@@ -59,7 +59,8 @@ impl TableCache {
         key: InternalKey<'_>,
     ) -> Result<Option<(Bytes, Bytes)>> {
         let tbl = self.get_table(file_num)?;
-        tbl.get(key).map(|opt| opt.map(|(k, v)| (k.into(), v.into())))
+        tbl.get(key)
+            .map(|opt| opt.map(|(k, v)| (k.into(), v.into())))
     }
 
     /// Return a table from cache, or open the backing file, then cache and return it.

--- a/src/table_cache.rs
+++ b/src/table_cache.rs
@@ -60,7 +60,7 @@ impl TableCache {
     ) -> Result<Option<(Bytes, Bytes)>> {
         let tbl = self.get_table(file_num)?;
         tbl.get(key)
-            .map(|opt| opt.map(|(k, v)| (k.into(), v.into())))
+            .map(|opt| opt)
     }
 
     /// Return a table from cache, or open the backing file, then cache and return it.

--- a/src/table_cache.rs
+++ b/src/table_cache.rs
@@ -15,6 +15,7 @@ use integer_encoding::FixedIntWriter;
 use std::convert::AsRef;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use bytes::Bytes;
 
 pub fn table_file_name<P: AsRef<Path>>(name: P, num: FileNum) -> PathBuf {
     assert!(num > 0);
@@ -56,9 +57,9 @@ impl TableCache {
         &mut self,
         file_num: FileNum,
         key: InternalKey<'_>,
-    ) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+    ) -> Result<Option<(Bytes, Bytes)>> {
         let tbl = self.get_table(file_num)?;
-        tbl.get(key)
+        tbl.get(key).map(|opt| opt.map(|(k, v)| (k.into(), v.into())))
     }
 
     /// Return a table from cache, or open the backing file, then cache and return it.

--- a/src/table_cache.rs
+++ b/src/table_cache.rs
@@ -60,7 +60,6 @@ impl TableCache {
     ) -> Result<Option<(Bytes, Bytes)>> {
         let tbl = self.get_table(file_num)?;
         tbl.get(key)
-            .map(|opt| opt)
     }
 
     /// Return a table from cache, or open the backing file, then cache and return it.

--- a/src/table_reader.rs
+++ b/src/table_reader.rs
@@ -15,8 +15,8 @@ use crate::types::{current_key_val, LdbIterator, Shared};
 use std::cmp::Ordering;
 use std::rc::Rc;
 
-use integer_encoding::FixedIntWriter;
 use bytes::Bytes;
+use integer_encoding::FixedIntWriter;
 
 /// Reads the table footer.
 fn read_footer(f: &dyn RandomAccess, size: usize) -> Result<Footer> {
@@ -741,7 +741,10 @@ mod tests {
         for (ref k, ref v) in LdbIteratorIter::wrap(&mut _iter) {
             assert_eq!(k.len(), 3 + 8);
             let (result_k, result_v) = table.get(k).unwrap().unwrap();
-            assert_eq!((k.to_vec(), v.to_vec()), (result_k.to_vec(), result_v.to_vec()));
+            assert_eq!(
+                (k.to_vec(), v.to_vec()),
+                (result_k.to_vec(), result_v.to_vec())
+            );
         }
 
         assert!(table

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -2,6 +2,7 @@ use crate::cmp::{Cmp, DefaultCmp};
 use crate::types::{current_key_val, LdbIterator};
 
 use std::cmp::Ordering;
+use bytes::Bytes;
 
 /// TestLdbIter is an LdbIterator over a vector, to be used for testing purposes.
 pub struct TestLdbIter<'a> {
@@ -37,15 +38,11 @@ impl<'a> LdbIterator for TestLdbIter<'a> {
         self.ix = 0;
         self.init = false;
     }
-    fn current(&self, key: &mut Vec<u8>, val: &mut Vec<u8>) -> bool {
+    fn current(&self) -> Option<(Bytes, Bytes)> {
         if self.init && self.ix < self.v.len() {
-            key.clear();
-            val.clear();
-            key.extend_from_slice(self.v[self.ix].0);
-            val.extend_from_slice(self.v[self.ix].1);
-            true
+            Some((Bytes::copy_from_slice(self.v[self.ix].0), Bytes::copy_from_slice(self.v[self.ix].1)))
         } else {
-            false
+            None
         }
     }
     fn valid(&self) -> bool {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,8 +1,8 @@
 use crate::cmp::{Cmp, DefaultCmp};
 use crate::types::{current_key_val, LdbIterator};
 
-use std::cmp::Ordering;
 use bytes::Bytes;
+use std::cmp::Ordering;
 
 /// TestLdbIter is an LdbIterator over a vector, to be used for testing purposes.
 pub struct TestLdbIter<'a> {
@@ -40,7 +40,10 @@ impl<'a> LdbIterator for TestLdbIter<'a> {
     }
     fn current(&self) -> Option<(Bytes, Bytes)> {
         if self.init && self.ix < self.v.len() {
-            Some((Bytes::copy_from_slice(self.v[self.ix].0), Bytes::copy_from_slice(self.v[self.ix].1)))
+            Some((
+                Bytes::copy_from_slice(self.v[self.ix].0),
+                Bytes::copy_from_slice(self.v[self.ix].1),
+            ))
         } else {
             None
         }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -21,7 +21,7 @@ impl<'a> TestLdbIter<'a> {
     }
 }
 
-impl<'a> LdbIterator for TestLdbIter<'a> {
+impl LdbIterator for TestLdbIter<'_> {
     fn advance(&mut self) -> bool {
         if self.ix == self.v.len() - 1 {
             self.ix += 1;
@@ -80,7 +80,7 @@ impl<'a, It: LdbIterator> LdbIteratorIter<'a, It> {
     }
 }
 
-impl<'a, It: LdbIterator> Iterator for LdbIteratorIter<'a, It> {
+impl<It: LdbIterator> Iterator for LdbIteratorIter<'_, It> {
     type Item = (Vec<u8>, Vec<u8>);
     fn next(&mut self) -> Option<Self::Item> {
         LdbIterator::next(self.inner)

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,8 @@ use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
 
+use bytes::Bytes;
+
 pub const NUM_LEVELS: usize = 7;
 
 /// Represents a sequence number of a single entry.
@@ -44,7 +46,7 @@ pub trait LdbIterator {
     /// becomes invalid (i.e. as if reset() had been called).
     fn advance(&mut self) -> bool;
     /// Return the current item (i.e. the item most recently returned by `next()`).
-    fn current(&self, key: &mut Vec<u8>, val: &mut Vec<u8>) -> bool;
+    fn current(&self) -> Option<(Bytes, Bytes)>;
     /// Seek the iterator to `key` or the next bigger key. If the seek is invalid (past last
     /// element, or before first element), the iterator is `reset()` and not valid.
     fn seek(&mut self, key: &[u8]);
@@ -67,9 +69,8 @@ pub trait LdbIterator {
         if !self.advance() {
             return None;
         }
-        let (mut key, mut val) = (vec![], vec![]);
-        if self.current(&mut key, &mut val) {
-            Some((key, val))
+        if let Some((key, val)) = self.current() {
+            Some((key.to_vec(), val.to_vec()))
         } else {
             None
         }
@@ -85,9 +86,8 @@ pub trait LdbIterator {
 /// current_key_val is a helper allocating two vectors and filling them with the current key/value
 /// of the specified iterator.
 pub fn current_key_val<It: LdbIterator + ?Sized>(it: &It) -> Option<(Vec<u8>, Vec<u8>)> {
-    let (mut k, mut v) = (vec![], vec![]);
-    if it.current(&mut k, &mut v) {
-        Some((k, v))
+    if let Some((k, v)) = it.current() {
+        Some((k.to_vec(), v.to_vec()))
     } else {
         None
     }
@@ -97,8 +97,8 @@ impl LdbIterator for Box<dyn LdbIterator> {
     fn advance(&mut self) -> bool {
         self.as_mut().advance()
     }
-    fn current(&self, key: &mut Vec<u8>, val: &mut Vec<u8>) -> bool {
-        self.as_ref().current(key, val)
+    fn current(&self) -> Option<(Bytes, Bytes)> {
+        self.as_ref().current()
     }
     fn seek(&mut self, key: &[u8]) {
         self.as_mut().seek(key)

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,8 +125,8 @@ pub struct FileMetaData {
     pub num: FileNum,
     pub size: usize,
     // these are in InternalKey format:
-    pub smallest: Vec<u8>,
-    pub largest: Vec<u8>,
+    pub smallest: Bytes,
+    pub largest: Bytes,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/version.rs
+++ b/src/version.rs
@@ -5,10 +5,10 @@ use crate::table_cache::TableCache;
 use crate::table_reader::TableIterator;
 use crate::types::{FileMetaData, FileNum, LdbIterator, Shared, MAX_SEQUENCE_NUMBER, NUM_LEVELS};
 
+use bytes::Bytes;
 use std::cmp::Ordering;
 use std::default::Default;
 use std::rc::Rc;
-use bytes::Bytes;
 
 /// FileMetaHandle is a reference-counted FileMetaData object with interior mutability. This is
 /// necessary to provide a shared metadata container that can be modified while referenced by e.g.
@@ -593,12 +593,20 @@ pub mod testutil {
         largest: &[u8],
         largestix: u64,
     ) -> FileMetaHandle {
+        let smallest_key = LookupKey::new(smallest, smallestix);
+        let largest_key = LookupKey::new(largest, largestix);
         share(FileMetaData {
             allowed_seeks: 10,
             size: 163840,
             num,
-            smallest: LookupKey::new(smallest, smallestix).internal_key().to_vec(),
-            largest: LookupKey::new(largest, largestix).internal_key().to_vec(),
+            smallest: LookupKey::new(smallest, smallestix)
+                .internal_key()
+                .to_vec()
+                .into(),
+            largest: LookupKey::new(largest, largestix)
+                .internal_key()
+                .to_vec()
+                .into(),
         })
     }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -593,8 +593,6 @@ pub mod testutil {
         largest: &[u8],
         largestix: u64,
     ) -> FileMetaHandle {
-        let smallest_key = LookupKey::new(smallest, smallestix);
-        let largest_key = LookupKey::new(largest, largestix);
         share(FileMetaData {
             allowed_seeks: 10,
             size: 163840,

--- a/src/version.rs
+++ b/src/version.rs
@@ -91,7 +91,7 @@ impl Version {
                     if typ == ValueType::TypeValue
                         && self.user_cmp.cmp(foundkey, ukey) == Ordering::Equal
                     {
-                        return Ok(Some((v.into(), stats)));
+                        return Ok(Some((v, stats)));
                     } else if typ == ValueType::TypeDeletion {
                         // Skip looking once we have found a deletion.
                         return Ok(None);


### PR DESCRIPTION
This PR contains serval commits that replace Vec<u8> with Bytes to reduce memory allocations and improve performance.

## Optimization Rationale

In the original code, extensive use of Vec<u8> leads to frequent memory allocations and copying operations, especially in key-value storage systems where these operations occur frequently. By using Bytes, we can:

- Reduce unnecessary memory allocations
- Use reference counting instead of deep copying
- Improve mainly iteration, batch write and compaction.