### PR TITLE
Ignore files with unrecognized names, instead of throwing an error.

### DIFF
--- a/src/db_impl.rs
+++ b/src/db_impl.rs
@@ -193,17 +193,13 @@ impl DB {
         let mut log_files = vec![];
 
         for file in &filenames {
-            match parse_file_name(file) {
-                Ok((num, typ)) => {
-                    expected.remove(&num);
-                    if typ == FileType::Log
-                        && (num >= self.vset.borrow().log_num
-                            || num == self.vset.borrow().prev_log_num)
-                    {
-                        log_files.push(num);
-                    }
+            if let Ok((num, typ)) = parse_file_name(file) {
+                expected.remove(&num);
+                if typ == FileType::Log
+                    && (num >= self.vset.borrow().log_num || num == self.vset.borrow().prev_log_num)
+                {
+                    log_files.push(num);
                 }
-                Err(e) => return Err(e.annotate(format!("While parsing {:?}", file))),
             }
         }
         if !expected.is_empty() {


### PR DESCRIPTION
# Current situation

At present, files with unrecognized / invalid names being present in the database folder cause an error when a `DB` is opened. The tests for the `parse_file_name` function give error examples like `xyz.LOCK`, `01a.sst`, and `MANIFEST-trolol`, which have aspects of valid filenames but are malformed. Unfortunately, `.DS_Store` (on MacOS after opening a LevelDB folder in Finder) and the `lost` directory (created by Minecraft Bedrock, or at least some past version of it, since one of my worlds included it) can be present in the database folder as well, with the only current solution being to remove those files / directories from the database folder before using this crate.

# Implemented solution

I think the best solution is to modify

> https://github.com/dermesser/leveldb-rs/blob/d5612f610a095fe8b5416f02df25961a7c055d56/src/db_impl.rs#L196-L207

to ignore the `Err` case, and not propagate an error further. That's what I've done in this pull request. This could probably count as a bug fix that would require only a patch version bump for semver, or a minor version bump if that's preferable. I ran `cargo test` and nothing failed. Hopefully, nobody is depending on a database throwing a particular error in order to test the existence of a file, so in practice this change should be compatible with existing uses.

# Alternative solutions

Perhaps it would be ideal to provide an option to error on unrecognized files (or to ignore them); the simplest approach would be to add something to the `Options` struct, but since it isn't marked `non_exhaustive`, that wouldn't be backwards-compatible and would require a bump to 4.0.0 to conform with semver. Another possible solution would be to vary behavior based on a compile-time environment variable, which feels messy.

Alternatively, the `parse_file_name` function could be changed to return an `Option<Result<(FileNum, FileType)>>`, and return `None` when some file of a completely unrecognized format as seen (but still return `Some(Err(_))` when a nearly-correct but malformed file is seen).

> https://github.com/dermesser/leveldb-rs/blob/d5612f610a095fe8b5416f02df25961a7c055d56/src/types.rs#L143

I'm not really sure where to draw the line with that, though; maybe any invalid `.log`, `.sst`, or `.dbtmp` file should throw an error? It seems better to not make a fine-grained arbitrary decision, and just ignore files with unrecognized / invalid names.

