### PR TITLE
Publicly export Snapshot (and minor changes)

### DIFF
--- a/src/db_impl.rs
+++ b/src/db_impl.rs
@@ -279,7 +279,6 @@ impl DB {
                 save_manifest = true;
                 mem = MemTable::new(cmp.clone());
             }
-            batch.clear();
         }
 
         // Check if we can reuse the last log file.

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -33,7 +33,7 @@ pub struct DBIterator {
 }
 
 impl DBIterator {
-    pub fn new(
+    pub(crate) fn new(
         cmp: Rc<Box<dyn Cmp>>,
         vset: Shared<VersionSet>,
         iter: MergingIter,

--- a/src/disk_env.rs
+++ b/src/disk_env.rs
@@ -161,7 +161,7 @@ impl Env for PosixDiskEnv {
             )
         } else {
             let f = locks.remove(&l.id).unwrap();
-            if f.unlock().is_err() {
+            if FileExt::unlock(&f).is_err() {
                 return err(StatusCode::LockError, &format!("unlock failed: {}", l.id));
             }
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,5 +109,6 @@ pub use filter::{BloomPolicy, FilterPolicy};
 pub use mem_env::MemEnv;
 pub use options::{in_memory, CompressorList, Options};
 pub use skipmap::SkipMap;
+pub use snapshot::Snapshot;
 pub use types::LdbIterator;
 pub use write_batch::WriteBatch;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -22,6 +22,8 @@ impl Drop for InnerSnapshot {
     }
 }
 
+/// Can be obtained from [`DB::get_snapshot`](crate::DB::get_snapshot), and used
+/// in some methods of the DB.
 #[derive(Clone)]
 pub struct Snapshot {
     inner: Rc<InnerSnapshot>,


### PR DESCRIPTION
## Motivation

I'm making a crate (well, collection of crates) for reading and writing MCBE worlds, and wanted to abstract over the implementation of LevelDB with a generic parameter, bounded by a trait specifying the interface. This trait includes a Snapshot associated type, and when I went to implement the trait for DB... well, `rusty_leveldb::snapshot::Snapshot` isn't publicly exported.

While I was at it, I looked for other visibility issues, and adjusted WriteBatch and DBIterator. The compiler also warned me about an issue in `mem_env.rs`.

## Changes
- Explicitly use `FileExt::unlock` in `mem_env.rs` to avoid a potential conflict with `std::fs::File::unlock` once the latter becomes stable. (`File::unlock` is/will be an inherent method, not a method from a trait, so it'd win the conflict.)
- Publicly reexport `Snapshot`, accessible as `rusty_leveldb::Snapshot`.
- Make the `new()` constructor of WriteBatch public (it was already publicly reachable anyway, as `WriteBatch::default()`).
- While I'm at it, improve the documentation for WriteBatch's encoding format. (I'm pretty sure I got the details right, but you might want to double-check.)
- Make `WriteBatch::clear` leave 12 header bytes set to zero, in line with `WriteBatch::new`, to ensure that the preceding calls to `put` or `delete` are cleared, and following `put`s and `delete`s can be performed. If this didn't count as a bug fix, it could require a larger version bump if semver were followed more strictly, but previously `WriteBatch::clear` would prevent following operations on it (except for `WriteBatch::set_contents`) from working properly; AFAICT there can't be any existing usages of `WriteBatch::clear` that would break which weren't already broken.
- Remove one unnecessary call to `WriteBatch::clear` in `db_impl.rs`, which would precede a call to `WriteBatch::set_contents` in a following loop iteration. `set_contents` already clears the Vec inside WriteBatch, so `clear` did and does nothing there.
- Change `DBIterator::new` to not be visible outside the crate, since one of the arguments to `new` (`MergingIter`) isn't publicly exported, and isn't returned from a publicly exported function (at least among what docs.rs can see).

## Notes
I don't know why `SkipMap` is publicly exported. But I don't think anyone outside the crate would be able to use SkipMap for anything. Might as well leave it to avoid the breaking change of removing it, but the next time the major version number is bumped, SkipMap should probably be limited to within the crate.