### PR TITLE
Use crc32c instead of crc32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/**/*", "src/*", "Cargo.toml", "LICENSE", "README.md"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-crc = "3.2"
+crc32c = "0.6.8"
 integer-encoding = "3.0"
 rand = "0.8.5"
 snap = "1.0"

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -1,11 +1,25 @@
-const CRC: crc::Crc<u32, crc::Table<1>> = crc::Crc::<u32, crc::Table<1>>::new(&crc::CRC_32_ISCSI);
-
 pub(crate) fn crc32(data: impl AsRef<[u8]>) -> u32 {
-    let mut digest = CRC.digest();
-    digest.update(data.as_ref());
-    digest.finalize()
+    crc32c::crc32c(data.as_ref())
 }
 
-pub(crate) fn digest() -> crc::Digest<'static, u32> {
-    CRC.digest()
+pub(crate) struct Digest {
+    hasher: crc32c::Crc32cHasher,
+}
+
+impl Digest {
+    pub fn update(&mut self, data: &[u8]) {
+        use std::hash::Hasher;
+        self.hasher.write(data);
+    }
+
+    pub fn finalize(self) -> u32 {
+        use std::hash::Hasher;
+        self.hasher.finish() as u32
+    }
+}
+
+pub(crate) fn digest() -> Digest {
+    Digest {
+        hasher: crc32c::Crc32cHasher::new(0),
+    }
 }


### PR DESCRIPTION
leveldb-rs currently uses crc-rs, but there are now many alternatives that support SIMD.

Weighing crc32c and crc32fast. crc32fast has a little performance advantages, but it uses IEEE 802.3 CRC32, while crc32c adopts the same Castagnoli as our current implementation.

After this commit, operations like put, batch write, and compact in leveldb-rs will improve by approximately 10% to 40%.