### PR TITLE
Refactor: Eliminate unsafe code and modernize thread safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ name = "maps_bench"
 harness = false
 path = "src/benches/maps_bench.rs"
 
+[[bench]]
+name = "cache_bench"
+harness = false
+path = "src/benches/cache_bench.rs"
+
 [workspace]
 members = [
   "examples/write-a-lot",

--- a/examples/kvserver/src/main.rs
+++ b/examples/kvserver/src/main.rs
@@ -1,9 +1,9 @@
-#![allow(static_mut_refs)]
 struct KVService {
     db: rusty_leveldb::DB,
 }
 
-static mut STORAGE_SERVICE: Option<std::sync::Mutex<KVService>> = None;
+static STORAGE_SERVICE: std::sync::OnceLock<std::sync::Mutex<KVService>> =
+    std::sync::OnceLock::new();
 
 impl KVService {
     fn handle_get(&mut self, req: &canteen::Request) -> canteen::Response {
@@ -37,31 +37,27 @@ impl KVService {
 }
 
 fn get_key_fn(rq: &canteen::Request) -> canteen::Response {
-    unsafe {
-        STORAGE_SERVICE
-            .as_ref()
-            .unwrap()
-            .lock()
-            .unwrap()
-            .handle_get(rq)
-    }
+    STORAGE_SERVICE
+        .get()
+        .unwrap()
+        .lock()
+        .unwrap()
+        .handle_get(rq)
 }
 
 fn put_key_fn(rq: &canteen::Request) -> canteen::Response {
-    unsafe {
-        STORAGE_SERVICE
-            .as_ref()
-            .unwrap()
-            .lock()
-            .unwrap()
-            .handle_put(rq)
-    }
+    STORAGE_SERVICE
+        .get()
+        .unwrap()
+        .lock()
+        .unwrap()
+        .handle_put(rq)
 }
 
 fn main() {
     let db = rusty_leveldb::DB::open("httpdb", rusty_leveldb::Options::default()).unwrap();
     let service = KVService { db };
-    unsafe { STORAGE_SERVICE = Some(std::sync::Mutex::new(service)) };
+    let _ = STORAGE_SERVICE.set(std::sync::Mutex::new(service));
 
     let mut ct = canteen::Canteen::new();
     ct.add_route("/kvs/get/<str:key>", &[canteen::Method::Get], get_key_fn);

--- a/examples/kvserver/src/main.rs
+++ b/examples/kvserver/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(static_mut_refs)]
 struct KVService {
     db: rusty_leveldb::DB,
 }

--- a/examples/leveldb-tool/src/main.rs
+++ b/examples/leveldb-tool/src/main.rs
@@ -9,7 +9,7 @@ use std::iter::FromIterator;
 fn get(db: &mut DB, k: &str) {
     match db.get(k.as_bytes()) {
         Some(v) => {
-            if let Ok(s) = String::from_utf8(v.to_vec().into()) {
+            if let Ok(s) = String::from_utf8(v.to_vec()) {
                 eprintln!("{} => {}", k, s);
             } else {
                 eprintln!("{} => {:?}", k, v);
@@ -31,14 +31,14 @@ fn delete(db: &mut DB, k: &str) {
 
 fn iter(db: &mut DB) {
     let mut it = db.new_iter().unwrap();
-    let (mut k, mut v) = (vec![], vec![]);
     let mut out = io::BufWriter::new(io::stdout());
     while it.advance() {
-        (k, v) = it.current();
-        out.write_all(&k).unwrap();
-        out.write_all(b" => ").unwrap();
-        out.write_all(&v).unwrap();
-        out.write_all(b"\n").unwrap();
+        if let Some((k, v)) = it.current() {
+            out.write_all(&k).unwrap();
+            out.write_all(b" => ").unwrap();
+            out.write_all(&v).unwrap();
+            out.write_all(b"\n").unwrap();
+        }
     }
 }
 

--- a/examples/mcpe/src/main.rs
+++ b/examples/mcpe/src/main.rs
@@ -2,7 +2,7 @@ use miniz_oxide::deflate::{compress_to_vec, compress_to_vec_zlib, CompressionLev
 use miniz_oxide::inflate::{decompress_to_vec, decompress_to_vec_zlib};
 use rusty_leveldb::compressor::NoneCompressor;
 use rusty_leveldb::{Compressor, CompressorList, Options, DB};
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// A zlib compressor that with zlib wrapper
 ///
@@ -76,7 +76,7 @@ pub fn mcpe_options(compression_level: u8) -> Options {
     list.set_with_id(0, NoneCompressor {});
     list.set_with_id(2, ZlibCompressor::new(compression_level));
     list.set_with_id(4, RawZlibCompressor::new(compression_level));
-    opt.compressor_list = Rc::new(list);
+    opt.compressor_list = Arc::new(list);
 
     // Set compressor
     // Minecraft bedrock may use other id than 4 however default is 4. [Mojang's implementation](https://github.com/reedacartwright/rbedrock/blob/fb32a899da4e15c1aaa0d6de2b459e914e183516/src/leveldb-mcpe/table/table_builder.cc#L152)

--- a/examples/mcpe/src/main.rs
+++ b/examples/mcpe/src/main.rs
@@ -100,5 +100,5 @@ fn main() {
     let mut db = DB::open(PATH, opt).unwrap();
     db.put(b"~local_player", b"NBT data goes here").unwrap();
     let value = db.get(b"~local_player").unwrap();
-    assert_eq!(value, b"NBT data goes here")
+    assert_eq!(value.as_ref(), b"NBT data goes here")
 }

--- a/src/benches/cache_bench.rs
+++ b/src/benches/cache_bench.rs
@@ -1,0 +1,31 @@
+#[macro_use]
+extern crate bencher;
+extern crate rusty_leveldb;
+
+use bencher::Bencher;
+use rusty_leveldb::cache::Cache;
+
+fn bench_cache_insert_evict(b: &mut Bencher) {
+    let mut cache = Cache::new(1000);
+    let mut i = 0u64;
+    b.iter(|| {
+        let mut key = [0u8; 16];
+        key[0..8].copy_from_slice(&i.to_le_bytes());
+        cache.insert(&key, i);
+        i += 1;
+    });
+}
+
+fn bench_cache_get_hit(b: &mut Bencher) {
+    let mut cache = Cache::new(1000);
+    let mut key = [0u8; 16];
+    key[0..8].copy_from_slice(&1u64.to_le_bytes());
+    cache.insert(&key, 1);
+
+    b.iter(|| {
+        bencher::black_box(cache.get(&key));
+    });
+}
+
+benchmark_group!(benches, bench_cache_insert_evict, bench_cache_get_hit,);
+benchmark_main!(benches);

--- a/src/benches/db_bench.rs
+++ b/src/benches/db_bench.rs
@@ -28,7 +28,7 @@ fn get_default_options() -> Options {
     let mut opts = Options::default();
     #[cfg(feature = "fs")]
     {
-        opts.env = std::rc::Rc::new(Box::new(rusty_leveldb::PosixDiskEnv::new()));
+        opts.env = std::sync::Arc::new(Box::new(rusty_leveldb::PosixDiskEnv::new()));
     }
     opts.create_if_missing = true;
     opts

--- a/src/benches/maps_bench.rs
+++ b/src/benches/maps_bench.rs
@@ -14,7 +14,7 @@ use rusty_leveldb::SkipMap;
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 fn gen_key_val<R: Rng>(gen: &mut R, keylen: usize, vallen: usize) -> (Vec<u8>, Vec<u8>) {
     let mut key = Vec::with_capacity(keylen);
@@ -40,7 +40,7 @@ fn bench_gen_key_val(b: &mut Bencher) {
 fn bench_skipmap_insert(b: &mut Bencher) {
     let mut gen = rand::thread_rng();
 
-    let mut skm = SkipMap::new(Rc::new(Box::new(DefaultCmp)));
+    let mut skm = SkipMap::new(Arc::new(Box::new(DefaultCmp)));
 
     b.iter(|| {
         let (mut k, v) = gen_key_val(&mut gen, 10, 10);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -238,6 +238,9 @@ impl<T> Cache<T> {
 }
 
 #[cfg(test)]
+unsafe impl<T> Send for Cache<T> {}
+unsafe impl<T> Sync for Cache<T> {}
+
 mod tests {
     use super::LRUList;
     use super::*;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,141 +1,154 @@
 use std::collections::HashMap;
-use std::mem::swap;
 
-// No clone, no copy! That asserts that an LRUHandle exists only once.
-struct LRUHandle<T>(*mut LRUNode<T>);
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct LRUHandle(usize);
 
 struct LRUNode<T> {
-    next: Option<Box<LRUNode<T>>>, // None in the list's last node
-    prev: Option<*mut LRUNode<T>>,
-    data: Option<T>, // if None, then we have reached the head node
+    next: Option<usize>,
+    prev: Option<usize>,
+    data: Option<T>, // None if it's the head node, or if it's a free slot
 }
 
 struct LRUList<T> {
-    head: LRUNode<T>,
+    nodes: Vec<LRUNode<T>>,
+    head: usize, // index of the dummy head node
+    free_head: Option<usize>,
     count: usize,
 }
 
-/// This is likely unstable; more investigation is needed into correct behavior!
 impl<T> LRUList<T> {
     fn new() -> LRUList<T> {
+        let nodes = vec![LRUNode {
+            next: None,
+            prev: None,
+            data: None,
+        }];
         LRUList {
-            head: LRUNode {
-                data: None,
-                next: None,
-                prev: None,
-            },
+            nodes,
+            head: 0,
+            free_head: None,
             count: 0,
         }
     }
 
-    /// Inserts new element at front (least recently used element)
-    fn insert(&mut self, elem: T) -> LRUHandle<T> {
-        self.count += 1;
-        // Not first element
-        if self.head.next.is_some() {
-            let mut new = Box::new(LRUNode {
-                data: Some(elem),
+    fn alloc_node(&mut self, data: T) -> usize {
+        if let Some(free_idx) = self.free_head {
+            self.free_head = self.nodes[free_idx].next;
+            self.nodes[free_idx] = LRUNode {
                 next: None,
-                prev: Some(&mut self.head as *mut LRUNode<T>),
-            });
-            let newp = new.as_mut() as *mut LRUNode<T>;
-
-            // Set up the node after the new one
-            self.head.next.as_mut().unwrap().prev = Some(newp);
-            // Replace head.next with None and set the new node's next to that
-            new.next = self.head.next.take();
-            self.head.next = Some(new);
-
-            LRUHandle(newp)
+                prev: None,
+                data: Some(data),
+            };
+            free_idx
         } else {
-            // First node; the only node right now is an empty head node
-            let mut new = Box::new(LRUNode {
-                data: Some(elem),
+            let idx = self.nodes.len();
+            self.nodes.push(LRUNode {
                 next: None,
-                prev: Some(&mut self.head as *mut LRUNode<T>),
+                prev: None,
+                data: Some(data),
             });
-            let newp = new.as_mut() as *mut LRUNode<T>;
-
-            // Set tail
-            self.head.prev = Some(newp);
-            // Set first node
-            self.head.next = Some(new);
-
-            LRUHandle(newp)
+            idx
         }
+    }
+
+    fn free_node(&mut self, idx: usize) -> T {
+        let data = self.nodes[idx].data.take().unwrap();
+        self.nodes[idx].next = self.free_head;
+        self.nodes[idx].prev = None;
+        self.free_head = Some(idx);
+        data
+    }
+
+    /// Inserts new element at front (least recently used element)
+    fn insert(&mut self, elem: T) -> LRUHandle {
+        let new_idx = self.alloc_node(elem);
+        self.count += 1;
+
+        let old_next = self.nodes[self.head].next;
+
+        self.nodes[new_idx].prev = Some(self.head);
+        self.nodes[new_idx].next = old_next;
+
+        self.nodes[self.head].next = Some(new_idx);
+
+        if let Some(old_next_idx) = old_next {
+            self.nodes[old_next_idx].prev = Some(new_idx);
+        } else {
+            self.nodes[self.head].prev = Some(new_idx); // track tail in head's prev
+        }
+
+        LRUHandle(new_idx)
     }
 
     fn remove_last(&mut self) -> Option<T> {
-        if self.count() == 0 {
+        if self.count == 0 {
             return None;
         }
-        let mut lasto = unsafe { (*((*self.head.prev.unwrap()).prev.unwrap())).next.take() };
+        let tail_idx = self.nodes[self.head].prev.unwrap();
+        let prev_idx = self.nodes[tail_idx].prev.unwrap();
 
-        assert!(lasto.is_some());
-        if let Some(ref mut last) = lasto {
-            assert!(last.prev.is_some());
-            assert!(self.head.prev.is_some());
-            self.head.prev = last.prev;
-            self.count -= 1;
-            last.data.take()
+        self.nodes[prev_idx].next = None;
+        if prev_idx == self.head {
+            self.nodes[self.head].prev = None;
         } else {
-            None
+            self.nodes[self.head].prev = Some(prev_idx);
         }
+
+        self.count -= 1;
+        Some(self.free_node(tail_idx))
     }
 
-    fn remove(&mut self, node_handle: LRUHandle<T>) -> T {
-        unsafe {
-            let d = (*node_handle.0).data.take().unwrap();
-            // Take ownership of node to be removed.
-            let mut current = (*(*node_handle.0).prev.unwrap()).next.take().unwrap();
-            let prev = current.prev.unwrap();
-            // Update previous node's successor.
-            if current.next.is_some() {
-                // Update next node's predecessor.
-                current.next.as_mut().unwrap().prev = current.prev.take();
+    fn remove(&mut self, node_handle: LRUHandle) -> T {
+        let idx = node_handle.0;
+        let prev_idx = self.nodes[idx].prev.unwrap();
+        let next_idx = self.nodes[idx].next;
+
+        self.nodes[prev_idx].next = next_idx;
+
+        if let Some(next_idx) = next_idx {
+            self.nodes[next_idx].prev = Some(prev_idx);
+        } else {
+            // Removing the tail
+            if self.count > 1 {
+                self.nodes[self.head].prev = Some(prev_idx);
             } else {
-                // Removing the tail: update head.prev to reflect the new tail.
-                // When removing the only element (count == 1), set head.prev to None.
-                self.head.prev = if self.count > 1 { Some(prev) } else { None };
+                self.nodes[self.head].prev = None;
             }
-            (*prev).next = current.next.take();
-
-            self.count -= 1;
-
-            d
         }
+
+        self.count -= 1;
+        self.free_node(idx)
     }
 
     /// Reinserts the referenced node at the front.
-    fn reinsert_front(&mut self, node_handle: &LRUHandle<T>) {
-        unsafe {
-            let prevp = (*node_handle.0).prev.unwrap();
+    fn reinsert_front(&mut self, node_handle: &LRUHandle) {
+        let idx = node_handle.0;
+        let prev_idx = self.nodes[idx].prev.unwrap();
+        let next_idx = self.nodes[idx].next;
 
-            // If not last node, update following node's prev
-            if let Some(next) = (*node_handle.0).next.as_mut() {
-                next.prev = Some(prevp);
-            } else {
-                // If last node, update head
-                self.head.prev = Some(prevp);
-            }
+        if prev_idx == self.head {
+            return; // Already at front
+        }
 
-            // Swap this.next with prev.next. After that, this.next refers to this (!)
-            swap(&mut (*prevp).next, &mut (*node_handle.0).next);
-            // To reinsert at head, swap head's next with this.next
-            swap(&mut (*node_handle.0).next, &mut self.head.next);
-            // Update this' prev reference to point to head.
+        // Remove from current position
+        self.nodes[prev_idx].next = next_idx;
+        if let Some(n) = next_idx {
+            self.nodes[n].prev = Some(prev_idx);
+        } else {
+            // It was the tail
+            self.nodes[self.head].prev = Some(prev_idx);
+        }
 
-            // Update the second node's prev reference.
-            if let Some(ref mut newnext) = (*node_handle.0).next {
-                (*node_handle.0).prev = newnext.prev;
-                newnext.prev = Some(node_handle.0);
-            } else {
-                // Only one node, being the last one; avoid head.prev pointing to head
-                self.head.prev = Some(node_handle.0);
-            }
+        // Insert at front
+        let old_next = self.nodes[self.head].next;
+        self.nodes[idx].prev = Some(self.head);
+        self.nodes[idx].next = old_next;
+        self.nodes[self.head].next = Some(idx);
 
-            assert!(self.head.next.is_some());
-            assert!(self.head.prev.is_some());
+        if let Some(old_next_idx) = old_next {
+            self.nodes[old_next_idx].prev = Some(idx);
+        } else {
+            self.nodes[self.head].prev = Some(idx);
         }
     }
 
@@ -144,8 +157,8 @@ impl<T> LRUList<T> {
     }
 
     fn _testing_head_ref(&self) -> Option<&T> {
-        if let Some(ref first) = self.head.next {
-            first.data.as_ref()
+        if let Some(first) = self.nodes[self.head].next {
+            self.nodes[first].data.as_ref()
         } else {
             None
         }
@@ -154,7 +167,7 @@ impl<T> LRUList<T> {
 
 pub type CacheKey = [u8; 16];
 pub type CacheID = u64;
-type CacheEntry<T> = (T, LRUHandle<CacheKey>);
+type CacheEntry<T> = (T, LRUHandle);
 
 /// Implementation of `ShardedLRUCache`.
 /// Based on a HashMap; the elements are linked in order to support the LRU ordering.
@@ -201,6 +214,10 @@ impl<T> Cache<T> {
     /// If the capacity has been reached, the least recently used element is removed from the
     /// cache.
     pub fn insert(&mut self, key: &CacheKey, elem: T) {
+        if let Some((_, old_handle)) = self.map.remove(key) {
+            self.list.remove(old_handle);
+        }
+
         if self.list.count() >= self.cap {
             if let Some(removed_key) = self.list.remove_last() {
                 assert!(self.map.remove(&removed_key).is_some());
@@ -216,12 +233,11 @@ impl<T> Cache<T> {
     /// Retrieve an element from the cache.
     /// If the element has been preempted from the cache in the meantime, this returns None.
     pub fn get<'a>(&'a mut self, key: &CacheKey) -> Option<&'a T> {
-        match self.map.get(key) {
-            None => None,
-            Some((elem, lru_handle)) => {
-                self.list.reinsert_front(lru_handle);
-                Some(elem)
-            }
+        if let Some((elem, lru_handle)) = self.map.get(key) {
+            self.list.reinsert_front(lru_handle);
+            Some(elem)
+        } else {
+            None
         }
     }
 
@@ -238,9 +254,6 @@ impl<T> Cache<T> {
 }
 
 #[cfg(test)]
-unsafe impl<T> Send for Cache<T> {}
-unsafe impl<T> Sync for Cache<T> {}
-
 mod tests {
     use super::LRUList;
     use super::*;
@@ -406,5 +419,22 @@ mod tests {
         assert_eq!(lru.remove_last(), Some(3));
         assert_eq!(lru.remove_last(), None);
         assert_eq!(lru.remove_last(), None);
+    }
+
+    #[test]
+    fn test_cache_duplicate_insert() {
+        let mut cache = Cache::new(2);
+        let key = make_key(1, 0, 0);
+        let key2 = make_key(2, 0, 0);
+        let key3 = make_key(3, 0, 0);
+
+        cache.insert(&key, 10);
+        cache.insert(&key, 20); // duplicate
+        cache.insert(&key2, 30);
+        cache.insert(&key3, 40);
+
+        assert_eq!(cache.get(&key), None); // key was evicted
+        assert_eq!(cache.get(&key2), Some(&30));
+        assert_eq!(cache.get(&key3), Some(&40));
     }
 }

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -2,13 +2,13 @@ use crate::key_types::{self, LookupKey};
 use crate::types;
 
 use std::cmp::Ordering;
-use std::rc::Rc;
+use std::sync::Arc;
 
-type WrappedCmp = Rc<Box<dyn Cmp>>;
+type WrappedCmp = Arc<Box<dyn Cmp>>;
 
 /// Comparator trait, supporting types that can be nested (i.e., add additional functionality on
 /// top of an inner comparator)
-pub trait Cmp {
+pub trait Cmp: Send + Sync {
     /// Compare to byte strings, bytewise.
     fn cmp(&self, a: &[u8], b: &[u8]) -> Ordering;
 
@@ -105,7 +105,7 @@ impl Cmp for DefaultCmp {
 
 /// Same as memtable_key_cmp, but for InternalKeys.
 #[derive(Clone)]
-pub struct InternalKeyCmp(pub Rc<Box<dyn Cmp>>);
+pub struct InternalKeyCmp(pub Arc<Box<dyn Cmp>>);
 
 impl Cmp for InternalKeyCmp {
     fn cmp(&self, a: &[u8], b: &[u8]) -> Ordering {
@@ -154,7 +154,7 @@ impl InternalKeyCmp {
 /// ordering the sequence numbers. (This means that when having an entry abx/4 and seRching for
 /// abx/5, then abx/4 is counted as "greater-or-equal", making snapshot functionality work at all)
 #[derive(Clone)]
-pub struct MemtableKeyCmp(pub Rc<Box<dyn Cmp>>);
+pub struct MemtableKeyCmp(pub Arc<Box<dyn Cmp>>);
 
 impl Cmp for MemtableKeyCmp {
     fn cmp(&self, a: &[u8], b: &[u8]) -> Ordering {
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn test_cmp_internalkeycmp_shortest_sep() {
-        let cmp = InternalKeyCmp(Rc::new(Box::new(DefaultCmp)));
+        let cmp = InternalKeyCmp(Arc::new(Box::new(DefaultCmp)));
         assert_eq!(
             cmp.find_shortest_sep(
                 LookupKey::new("abcd".as_bytes(), 1).internal_key(),
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_cmp_internalkeycmp() {
-        let cmp = InternalKeyCmp(Rc::new(Box::new(DefaultCmp)));
+        let cmp = InternalKeyCmp(Arc::new(Box::new(DefaultCmp)));
         // a < b < c
         let a = LookupKey::new("abc".as_bytes(), 2).internal_key().to_vec();
         let b = LookupKey::new("abc".as_bytes(), 1).internal_key().to_vec();
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_cmp_memtablekeycmp_panics() {
-        let cmp = MemtableKeyCmp(Rc::new(Box::new(DefaultCmp)));
+        let cmp = MemtableKeyCmp(Arc::new(Box::new(DefaultCmp)));
         cmp.cmp(&[1, 2, 3], &[4, 5, 6]);
     }
 }

--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -25,7 +25,7 @@
 /// ```
 ///
 /// See [crate::CompressorList] for usage
-pub trait Compressor {
+pub trait Compressor: Send + Sync {
     fn encode(&self, block: Vec<u8>) -> crate::Result<Vec<u8>>;
 
     fn decode(&self, block: Vec<u8>) -> crate::Result<Vec<u8>>;

--- a/src/db_impl.rs
+++ b/src/db_impl.rs
@@ -37,7 +37,7 @@ use std::mem;
 use std::ops::Drop;
 use std::path::Path;
 use std::path::PathBuf;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// DB contains the actual database implemenation. As opposed to the original, this implementation
 /// is not concurrent (yet).
@@ -46,14 +46,14 @@ pub struct DB {
     path: PathBuf,
     lock: Option<FileLock>,
 
-    internal_cmp: Rc<Box<dyn Cmp>>,
+    internal_cmp: Arc<Box<dyn Cmp>>,
     fpol: InternalFilterPolicy<BoxedFilterPolicy>,
     opt: Options,
 
     mem: MemTable,
     imm: Option<MemTable>,
 
-    log: Option<LogWriter<BufWriter<Box<dyn Write>>>>,
+    log: Option<LogWriter<BufWriter<Box<dyn std::io::Write + Send + Sync>>>>,
     log_num: Option<FileNum>,
     cache: Shared<TableCache>,
     vset: Shared<VersionSet>,
@@ -61,8 +61,6 @@ pub struct DB {
 
     cstats: [CompactionStats; NUM_LEVELS],
 }
-
-unsafe impl Send for DB {}
 
 impl DB {
     // RECOVERY AND INITIALIZATION //
@@ -88,7 +86,7 @@ impl DB {
             name: name.to_owned(),
             path,
             lock: None,
-            internal_cmp: Rc::new(Box::new(InternalKeyCmp(opt.cmp.clone()))),
+            internal_cmp: Arc::new(Box::new(InternalKeyCmp(opt.cmp.clone()))),
             fpol: InternalFilterPolicy::new(opt.filter_policy.clone()),
 
             mem: MemTable::new(opt.cmp.clone()),
@@ -107,7 +105,7 @@ impl DB {
     }
 
     fn current(&self) -> Shared<Version> {
-        self.vset.borrow().current()
+        self.vset.read().unwrap().current()
     }
 
     /// Opens or creates a new or existing database. `name` is the name of the directory containing
@@ -123,7 +121,7 @@ impl DB {
 
         // Create log file if an old one is not being reused.
         if db.log.is_none() {
-            let lognum = db.vset.borrow_mut().new_file_number();
+            let lognum = db.vset.write().unwrap().new_file_number();
             let logfile = db
                 .opt
                 .env
@@ -135,7 +133,7 @@ impl DB {
 
         if save_manifest {
             ve.set_log_num(db.log_num.unwrap_or(0));
-            db.vset.borrow_mut().log_and_apply(ve)?;
+            db.vset.write().unwrap().log_and_apply(ve)?;
         }
 
         db.delete_obsolete_files()?;
@@ -184,19 +182,20 @@ impl DB {
 
         // If save_manifest is true, we should log_and_apply() later in order to write the new
         // manifest.
-        let mut save_manifest = self.vset.borrow_mut().recover()?;
+        let mut save_manifest = self.vset.write().unwrap().recover()?;
 
         // Recover from all log files not in the descriptor.
         let mut max_seq = 0;
         let filenames = self.opt.env.children(&self.path)?;
-        let mut expected = self.vset.borrow().live_files();
+        let mut expected = self.vset.read().unwrap().live_files();
         let mut log_files = vec![];
 
         for file in &filenames {
             if let Ok((num, typ)) = parse_file_name(file) {
                 expected.remove(&num);
                 if typ == FileType::Log
-                    && (num >= self.vset.borrow().log_num || num == self.vset.borrow().prev_log_num)
+                    && (num >= self.vset.read().unwrap().log_num
+                        || num == self.vset.read().unwrap().prev_log_num)
                 {
                     log_files.push(num);
                 }
@@ -217,11 +216,14 @@ impl DB {
             if max_seq_ > max_seq {
                 max_seq = max_seq_;
             }
-            self.vset.borrow_mut().mark_file_number_used(log_files[i]);
+            self.vset
+                .write()
+                .unwrap()
+                .mark_file_number_used(log_files[i]);
         }
 
-        if self.vset.borrow().last_seq < max_seq {
-            self.vset.borrow_mut().last_seq = max_seq;
+        if self.vset.read().unwrap().last_seq < max_seq {
+            self.vset.write().unwrap().last_seq = max_seq;
         }
 
         Ok(save_manifest)
@@ -239,7 +241,7 @@ impl DB {
         let filename = log_file_name(&self.path, log_num);
         let logfile = self.opt.env.open_sequential_file(Path::new(&filename))?;
         // Use the user-supplied comparator; it will be wrapped inside a MemtableKeyCmp.
-        let cmp: Rc<Box<dyn Cmp>> = self.opt.cmp.clone();
+        let cmp: Arc<Box<dyn Cmp>> = self.opt.cmp.clone();
 
         let mut logreader = LogReader::new(
             logfile, // checksum=
@@ -304,18 +306,18 @@ impl DB {
 
     /// delete_obsolete_files removes files that are no longer needed from the file system.
     fn delete_obsolete_files(&mut self) -> Result<()> {
-        let files = self.vset.borrow().live_files();
+        let files = self.vset.read().unwrap().live_files();
         let filenames = self.opt.env.children(Path::new(&self.path))?;
         for name in filenames {
             if let Ok((num, typ)) = parse_file_name(&name) {
                 match typ {
                     FileType::Log => {
-                        if num >= self.vset.borrow().log_num {
+                        if num >= self.vset.read().unwrap().log_num {
                             continue;
                         }
                     }
                     FileType::Descriptor => {
-                        if num >= self.vset.borrow().manifest_num {
+                        if num >= self.vset.read().unwrap().manifest_num {
                             continue;
                         }
                     }
@@ -336,7 +338,7 @@ impl DB {
 
                 // If we're here, delete this file.
                 if typ == FileType::Table {
-                    let _ = self.cache.borrow_mut().evict(num);
+                    let _ = self.cache.read().unwrap().evict(num);
                 }
                 log!(self.opt.log, "Deleting file type={:?} num={}", typ, num);
                 if let Err(e) = self.opt.env.delete(&self.path.join(&name)) {
@@ -408,14 +410,14 @@ impl DB {
 
         let entries = batch.count() as u64;
         let log = self.log.as_mut().unwrap();
-        let next = self.vset.borrow().last_seq + 1;
+        let next = self.vset.read().unwrap().last_seq + 1;
 
         batch.insert_into_memtable(next, &mut self.mem);
         log.add_record(&batch.encode(next))?;
         if sync {
             log.flush()?;
         }
-        self.vset.borrow_mut().last_seq += entries;
+        self.vset.write().unwrap().last_seq += entries;
         Ok(())
     }
 
@@ -460,7 +462,7 @@ impl DB {
         // Limiting the borrow scope of self.current.
         {
             let current = self.current();
-            let mut current = current.borrow_mut();
+            let mut current = current.write().unwrap();
             if let Ok(Some((v, st))) = current.get(lkey.internal_key()) {
                 if current.update_stats(st) {
                     do_compaction = true;
@@ -485,7 +487,7 @@ impl DB {
 
     /// get is a simplified version of get_at(), translating errors to None.
     pub fn get(&mut self, key: &[u8]) -> Option<Bytes> {
-        let seq = self.vset.borrow().last_seq;
+        let seq = self.vset.read().unwrap().last_seq;
         self.get_internal(seq, key).unwrap_or_default()
     }
 }
@@ -525,7 +527,7 @@ impl DB {
 
         // Add iterators for table files.
         let current = self.current();
-        let current = current.borrow();
+        let current = current.read().unwrap();
         iters.extend(current.new_iters()?);
 
         Ok(MergingIter::new(self.internal_cmp.clone(), iters))
@@ -538,7 +540,7 @@ impl DB {
     /// Returns a snapshot at the current state. It can be used to retrieve entries from the
     /// database as they were at an earlier point in time.
     pub fn get_snapshot(&mut self) -> Snapshot {
-        self.snaps.new_snapshot(self.vset.borrow().last_seq)
+        self.snaps.new_snapshot(self.vset.read().unwrap().last_seq)
     }
 }
 
@@ -552,7 +554,7 @@ impl DB {
     /// Trigger a compaction based on where this key is located in the different levels.
     fn record_read_sample(&mut self, k: InternalKey<'_>) {
         let current = self.current();
-        if current.borrow_mut().record_read_sample(k) {
+        if current.write().unwrap().record_read_sample(k) {
             if let Err(e) = self.maybe_do_compaction() {
                 log!(self.opt.log, "record_read_sample: compaction failed: {}", e);
             }
@@ -571,7 +573,7 @@ impl DB {
             Ok(())
         } else {
             // Create new memtable.
-            let logn = self.vset.borrow_mut().new_file_number();
+            let logn = self.vset.write().unwrap().new_file_number();
             let logf = self
                 .opt
                 .env
@@ -586,7 +588,7 @@ impl DB {
                 self.imm = Some(imm);
                 self.maybe_do_compaction()
             } else {
-                self.vset.borrow_mut().reuse_file_number(logn);
+                self.vset.write().unwrap().reuse_file_number(logn);
                 Err(logf.err().unwrap())
             }
         }
@@ -599,8 +601,8 @@ impl DB {
         }
         // Issue #34 PR #36: after compacting a memtable into an L0 file, it is possible that the
         // L0 files need to be merged and promoted.
-        if self.vset.borrow().needs_compaction() {
-            let c = self.vset.borrow_mut().pick_compaction();
+        if self.vset.read().unwrap().needs_compaction() {
+            let c = self.vset.write().unwrap().pick_compaction();
             if let Some(c) = c {
                 self.start_compaction(c)
             } else {
@@ -619,8 +621,8 @@ impl DB {
     pub fn compact_range(&mut self, from: &[u8], to: &[u8]) -> Result<()> {
         let mut max_level = 1;
         {
-            let v = self.vset.borrow().current();
-            let v = v.borrow();
+            let v = self.vset.read().unwrap().current();
+            let v = v.read().unwrap();
             for l in 1..NUM_LEVELS - 1 {
                 if v.overlap_in_level(l, from, to) {
                     max_level = l;
@@ -640,7 +642,8 @@ impl DB {
             loop {
                 let c_ = self
                     .vset
-                    .borrow_mut()
+                    .write()
+                    .unwrap()
                     .compact_range(l, &ifrom, iend.internal_key());
                 if let Some(c) = c_ {
                     // Update ifrom to the largest key of the last file in this compaction.
@@ -668,7 +671,11 @@ impl DB {
             compaction.edit().delete_file(level, num);
             compaction.edit().add_file(level + 1, f);
 
-            let r = self.vset.borrow_mut().log_and_apply(compaction.into_edit());
+            let r = self
+                .vset
+                .write()
+                .unwrap()
+                .log_and_apply(compaction.into_edit());
             if let Err(e) = r {
                 log!(self.opt.log, "trivial move failed: {}", e);
                 Err(e)
@@ -684,13 +691,13 @@ impl DB {
                 log!(
                     self.opt.log,
                     "Summary: {}",
-                    self.vset.borrow().current_summary()
+                    self.vset.read().unwrap().current_summary()
                 );
                 Ok(())
             }
         } else {
             let smallest = if self.snaps.empty() {
-                self.vset.borrow().last_seq
+                self.vset.read().unwrap().last_seq
             } else {
                 self.snaps.oldest()
             };
@@ -703,7 +710,7 @@ impl DB {
             log!(
                 self.opt.log,
                 "Compaction finished: {}",
-                self.vset.borrow().current_summary()
+                self.vset.read().unwrap().current_summary()
             );
 
             self.delete_obsolete_files()
@@ -717,12 +724,12 @@ impl DB {
         let base = self.current();
 
         let imm = self.imm.take().unwrap();
-        if let Err(e) = self.write_l0_table(&imm, &mut ve, Some(&base.borrow())) {
+        if let Err(e) = self.write_l0_table(&imm, &mut ve, Some(&base.read().unwrap())) {
             self.imm = Some(imm);
             return Err(e);
         }
         ve.set_log_num(self.log_num.unwrap_or(0));
-        self.vset.borrow_mut().log_and_apply(ve)?;
+        self.vset.write().unwrap().log_and_apply(ve)?;
         if let Err(e) = self.delete_obsolete_files() {
             log!(self.opt.log, "Error deleting obsolete files: {}", e);
         }
@@ -737,18 +744,18 @@ impl DB {
         base: Option<&Version>,
     ) -> Result<()> {
         let start_ts = self.opt.env.micros();
-        let num = self.vset.borrow_mut().new_file_number();
+        let num = self.vset.write().unwrap().new_file_number();
         log!(self.opt.log, "Start write of L0 table {:06}", num);
         let fmd = build_table(&self.path, &self.opt, memt.iter(), num)?;
         log!(self.opt.log, "L0 table {:06} has {} bytes", num, fmd.size);
 
         // Wrote empty table.
         if fmd.size == 0 {
-            self.vset.borrow_mut().reuse_file_number(num);
+            self.vset.write().unwrap().reuse_file_number(num);
             return Ok(());
         }
 
-        let cache_result = self.cache.borrow_mut().get_table(num);
+        let cache_result = self.cache.read().unwrap().get_table(num);
         if let Err(e) = cache_result {
             log!(
                 self.opt.log,
@@ -785,8 +792,14 @@ impl DB {
 
     fn do_compaction_work(&mut self, cs: &mut CompactionState) -> Result<()> {
         {
-            let current = self.vset.borrow().current();
-            assert!(current.borrow().num_level_files(cs.compaction.level()) > 0);
+            let current = self.vset.read().unwrap().current();
+            assert!(
+                current
+                    .read()
+                    .unwrap()
+                    .num_level_files(cs.compaction.level())
+                    > 0
+            );
             assert!(cs.builder.is_none());
         }
         let start_ts = self.opt.env.micros();
@@ -799,7 +812,11 @@ impl DB {
             cs.compaction.level() + 1
         );
 
-        let mut input = self.vset.borrow().make_input_iterator(&cs.compaction);
+        let mut input = self
+            .vset
+            .read()
+            .unwrap()
+            .make_input_iterator(&cs.compaction);
         input.seek_to_first();
 
         let mut last_seq_for_key = MAX_SEQUENCE_NUMBER;
@@ -854,7 +871,7 @@ impl DB {
             last_seq_for_key = seq;
 
             if cs.builder.is_none() {
-                let fnum = self.vset.borrow_mut().new_file_number();
+                let fnum = self.vset.write().unwrap().new_file_number();
                 let fmd = FileMetaData {
                     num: fnum,
                     ..Default::default()
@@ -917,7 +934,7 @@ impl DB {
         if entries > 0 {
             // Verify that table can be used. (Separating get_table() because borrowing in an if
             // let expression is dangerous).
-            let r = self.cache.borrow_mut().get_table(output_num);
+            let r = self.cache.read().unwrap().get_table(output_num);
             if let Err(e) = r {
                 log!(self.opt.log, "New table can't be read: {}", e);
                 return Err(e);
@@ -949,7 +966,8 @@ impl DB {
             cs.compaction.edit().add_file(level + 1, output.clone());
         }
         self.vset
-            .borrow_mut()
+            .write()
+            .unwrap()
             .log_and_apply(cs.compaction.into_edit())
     }
 }
@@ -965,7 +983,7 @@ struct CompactionState {
     compaction: Compaction,
     smallest_seq: SequenceNumber,
     outputs: Vec<FileMetaData>,
-    builder: Option<TableBuilder<Box<dyn Write>>>,
+    builder: Option<TableBuilder<Box<dyn std::io::Write + Send + Sync>>>,
     total_bytes: usize,
 }
 
@@ -1114,7 +1132,7 @@ pub mod testutil {
 
         for l in 0..NUM_LEVELS {
             for f in &v.files[l] {
-                ve.add_file(l, f.borrow().clone());
+                ve.add_file(l, f.read().unwrap().clone());
             }
         }
 
@@ -1131,12 +1149,12 @@ pub mod testutil {
     /// set_file_to_compact ensures that the specified table file will be compacted next.
     pub fn set_file_to_compact(db: &mut DB, num: FileNum) {
         let v = db.current();
-        let mut v = v.borrow_mut();
+        let mut v = v.write().unwrap();
 
         let mut ftc = None;
         for l in 0..NUM_LEVELS {
             for f in &v.files[l] {
-                if f.borrow().num == num {
+                if f.read().unwrap().num == num {
                     ftc = Some((f.clone(), l));
                 }
             }
@@ -1280,11 +1298,12 @@ mod tests {
             assert!(env.exists(&Path::new("db").join("000004.log")).unwrap());
             // Check that entry exists and is correct. Phew, long call chain!
             let current = db.current();
-            log!(opt.log, "files: {:?}", current.borrow().files);
+            log!(opt.log, "files: {:?}", current.read().unwrap().files);
             assert_eq!(
                 b"def",
                 current
-                    .borrow_mut()
+                    .write()
+                    .unwrap()
                     .get(LookupKey::new(b"abc", 1).internal_key())
                     .unwrap()
                     .unwrap()
@@ -1474,7 +1493,7 @@ mod tests {
 
         {
             // Read table back in.
-            let mut tc = TableCache::new("db", opt.clone(), share(Cache::new(128)), 100);
+            let tc = TableCache::new("db", opt.clone(), share(Cache::new(128)), 100);
             let tbl = tc.get_table(123).unwrap();
             assert_eq!(mt.len(), LdbIteratorIter::wrap(&mut tbl.iter()).count());
         }
@@ -1494,7 +1513,7 @@ mod tests {
                 .write_all(&buf)
                 .unwrap();
 
-            let mut tc = TableCache::new("db", opt.clone(), share(Cache::new(128)), 100);
+            let tc = TableCache::new("db", opt.clone(), share(Cache::new(128)), 100);
             let tbl = tc.get_table(123).unwrap();
             // The last two entries are skipped due to the corruption above.
             assert_eq!(
@@ -1520,7 +1539,7 @@ mod tests {
     fn test_db_impl_get_from_table_with_snapshot() {
         let mut db = build_db().0;
 
-        assert_eq!(30, db.vset.borrow().last_seq);
+        assert_eq!(30, db.vset.read().unwrap().last_seq);
 
         // seq = 31
         db.put(b"xyy", b"123").unwrap();
@@ -1612,7 +1631,7 @@ mod tests {
 
         {
             let v = db.current();
-            let mut v = v.borrow_mut();
+            let mut v = v.write().unwrap();
             v.file_to_compact = Some(v.files[2][0].clone());
             v.file_to_compact_lvl = 2;
         }
@@ -1621,7 +1640,7 @@ mod tests {
 
         {
             let v = db.current();
-            let v = v.borrow_mut();
+            let v = v.write().unwrap();
             assert_eq!(1, v.files[3].len());
         }
     }
@@ -1657,7 +1676,8 @@ mod tests {
         );
         assert_eq!(
             7,
-            LdbIteratorIter::wrap(&mut db.cache.borrow_mut().get_table(3).unwrap().iter()).count()
+            LdbIteratorIter::wrap(&mut db.cache.read().unwrap().get_table(3).unwrap().iter())
+                .count()
         );
     }
 
@@ -1665,8 +1685,8 @@ mod tests {
     fn test_db_impl_compaction() {
         let mut db = build_db().0;
         let v = db.current();
-        v.borrow_mut().compaction_score = Some(2.0);
-        v.borrow_mut().compaction_level = Some(1);
+        v.write().unwrap().compaction_score = Some(2.0);
+        v.write().unwrap().compaction_level = Some(1);
 
         db.maybe_do_compaction().unwrap();
 
@@ -1690,8 +1710,8 @@ mod tests {
 
         // New current version.
         let v = db.current();
-        assert_eq!(0, v.borrow().files[1].len());
-        assert_eq!(2, v.borrow().files[2].len());
+        assert_eq!(0, v.read().unwrap().files[1].len());
+        assert_eq!(2, v.read().unwrap().files[2].len());
     }
 
     #[test]
@@ -1703,8 +1723,8 @@ mod tests {
         v.file_to_compact_lvl = 2;
 
         let mut db = DB::new("db", opt.clone());
-        db.vset.borrow_mut().add_version(v);
-        db.vset.borrow_mut().next_file_num = 10;
+        db.vset.write().unwrap().add_version(v);
+        db.vset.write().unwrap().next_file_num = 10;
 
         db.maybe_do_compaction().unwrap();
 
@@ -1718,8 +1738,8 @@ mod tests {
         );
 
         let v = db.current();
-        assert_eq!(1, v.borrow().files[2].len());
-        assert_eq!(3, v.borrow().files[3].len());
+        assert_eq!(1, v.read().unwrap().files[2].len());
+        assert_eq!(3, v.read().unwrap().files[3].len());
     }
 
     #[test]
@@ -1822,5 +1842,15 @@ mod tests {
             db.write(write_batch, false).unwrap();
             cnt += entries_per_batch;
         }
+    }
+}
+
+#[cfg(test)]
+mod test_send {
+    use super::*;
+    fn is_send<T: Send>() {}
+    #[test]
+    fn test_db_send() {
+        is_send::<DB>();
     }
 }

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -8,14 +8,14 @@ use crate::version_set::VersionSet;
 use bytes::Bytes;
 use std::cmp::Ordering;
 use std::mem;
-use std::rc::Rc;
+use std::sync::Arc;
 
 const READ_BYTES_PERIOD: isize = 1048576;
 
 /// DBIterator is an iterator over the contents of a database.
 pub struct DBIterator {
     // A user comparator.
-    cmp: Rc<Box<dyn Cmp>>,
+    cmp: Arc<Box<dyn Cmp>>,
     vset: Shared<VersionSet>,
     iter: MergingIter,
     // By holding onto a snapshot, we make sure that the iterator iterates over the state at the
@@ -35,7 +35,7 @@ pub struct DBIterator {
 
 impl DBIterator {
     pub fn new(
-        cmp: Rc<Box<dyn Cmp>>,
+        cmp: Arc<Box<dyn Cmp>>,
         vset: Shared<VersionSet>,
         iter: MergingIter,
         ss: Snapshot,
@@ -61,8 +61,8 @@ impl DBIterator {
     fn record_read_sample(&mut self, len: usize) {
         self.byte_count -= len as isize;
         if self.byte_count < 0 {
-            let v = self.vset.borrow().current();
-            v.borrow_mut().record_read_sample(&self.keybuf);
+            let v = self.vset.read().unwrap().current();
+            v.write().unwrap().record_read_sample(&self.keybuf);
             while self.byte_count < 0 {
                 self.byte_count += random_period();
             }

--- a/src/disk_env.rs
+++ b/src/disk_env.rs
@@ -6,7 +6,7 @@ use fs2::FileExt;
 
 use std::collections::HashMap;
 use std::fs::{self, File};
-use std::io::{self, ErrorKind, Read, Write};
+use std::io::{self, ErrorKind, Read};
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 
@@ -59,7 +59,7 @@ impl Env for PosixDiskEnv {
             })
             .map_err(|e| map_err_with_name("open (randomaccess)", p, e))
     }
-    fn open_writable_file(&self, p: &Path) -> Result<Box<dyn Write>> {
+    fn open_writable_file(&self, p: &Path) -> Result<Box<dyn std::io::Write + Send + Sync>> {
         Ok(Box::new(
             fs::OpenOptions::new()
                 .create(true)
@@ -70,7 +70,7 @@ impl Env for PosixDiskEnv {
                 .map_err(|e| map_err_with_name("open (write)", p, e))?,
         ))
     }
-    fn open_appendable_file(&self, p: &Path) -> Result<Box<dyn Write>> {
+    fn open_appendable_file(&self, p: &Path) -> Result<Box<dyn std::io::Write + Send + Sync>> {
         Ok(Box::new(
             fs::OpenOptions::new()
                 .create(true)
@@ -115,7 +115,7 @@ impl Env for PosixDiskEnv {
     }
 
     fn lock(&self, p: &Path) -> Result<FileLock> {
-        let mut locks = self.locks.borrow_mut();
+        let mut locks = self.locks.write().unwrap();
 
         if let std::collections::hash_map::Entry::Vacant(e) =
             locks.entry(p.to_str().unwrap().to_string())
@@ -153,7 +153,7 @@ impl Env for PosixDiskEnv {
         }
     }
     fn unlock(&self, l: FileLock) -> Result<()> {
-        let mut locks = self.locks.borrow_mut();
+        let mut locks = self.locks.write().unwrap();
         if !locks.contains_key(&l.id) {
             err(
                 StatusCode::LockError,

--- a/src/env.rs
+++ b/src/env.rs
@@ -11,7 +11,7 @@ use std::os::unix::fs::FileExt;
 use std::os::windows::fs::FileExt;
 use std::path::{Path, PathBuf};
 
-pub trait RandomAccess {
+pub trait RandomAccess: Send + Sync {
     fn read_at(&self, off: usize, dst: &mut [u8]) -> Result<usize>;
 }
 
@@ -33,11 +33,11 @@ pub struct FileLock {
     pub id: String,
 }
 
-pub trait Env {
+pub trait Env: Send + Sync {
     fn open_sequential_file(&self, _: &Path) -> Result<Box<dyn Read>>;
     fn open_random_access_file(&self, _: &Path) -> Result<Box<dyn RandomAccess>>;
-    fn open_writable_file(&self, _: &Path) -> Result<Box<dyn Write>>;
-    fn open_appendable_file(&self, _: &Path) -> Result<Box<dyn Write>>;
+    fn open_writable_file(&self, _: &Path) -> Result<Box<dyn std::io::Write + Send + Sync>>;
+    fn open_appendable_file(&self, _: &Path) -> Result<Box<dyn std::io::Write + Send + Sync>>;
 
     fn exists(&self, _: &Path) -> Result<bool>;
     fn children(&self, _: &Path) -> Result<Vec<PathBuf>>;
@@ -58,11 +58,11 @@ pub trait Env {
 }
 
 pub struct Logger {
-    dst: Box<dyn Write>,
+    dst: Box<dyn std::io::Write + Send + Sync>,
 }
 
 impl Logger {
-    pub fn new(w: Box<dyn Write>) -> Logger {
+    pub fn new(w: Box<dyn std::io::Write + Send + Sync>) -> Logger {
         Logger { dst: w }
     }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,11 +1,11 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use integer_encoding::FixedInt;
 
 /// Encapsulates a filter algorithm allowing to search for keys more efficiently.
 /// Usually, policies are used as a BoxedFilterPolicy (see below), so they
 /// can be easily cloned and nested.
-pub trait FilterPolicy {
+pub trait FilterPolicy: Send + Sync {
     /// Returns a string identifying this policy.
     fn name(&self) -> &'static str;
     /// Create a filter matching the given keys. Keys are given as a long byte array that is
@@ -17,7 +17,7 @@ pub trait FilterPolicy {
 
 /// A boxed and refcounted filter policy (reference-counted because a Box with unsized content
 /// couldn't be cloned otherwise)
-pub type BoxedFilterPolicy = Rc<Box<dyn FilterPolicy>>;
+pub type BoxedFilterPolicy = Arc<Box<dyn FilterPolicy>>;
 
 impl FilterPolicy for BoxedFilterPolicy {
     fn name(&self) -> &'static str {
@@ -258,7 +258,7 @@ mod tests {
 
     /// Creates a filter using the keys from input_data() but converted to InternalKey format.
     fn create_internalkey_filter() -> Vec<u8> {
-        let fpol = Rc::new(Box::new(InternalFilterPolicy::new(BloomPolicy::new(
+        let fpol = Arc::new(Box::new(InternalFilterPolicy::new(BloomPolicy::new(
             _BITS_PER_KEY,
         ))));
         let (data, offs) = input_data();

--- a/src/filter_block.rs
+++ b/src/filter_block.rs
@@ -1,7 +1,7 @@
 use crate::block::BlockContents;
 use crate::filter::BoxedFilterPolicy;
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use integer_encoding::FixedInt;
 
@@ -107,7 +107,7 @@ impl FilterBlockBuilder {
 #[derive(Clone)]
 pub struct FilterBlockReader {
     policy: BoxedFilterPolicy,
-    block: Rc<BlockContents>,
+    block: Arc<BlockContents>,
 
     offsets_offset: usize,
     filter_base_lg2: u32,
@@ -115,10 +115,10 @@ pub struct FilterBlockReader {
 
 impl FilterBlockReader {
     pub fn new_owned(pol: BoxedFilterPolicy, data: Vec<u8>) -> FilterBlockReader {
-        FilterBlockReader::new(pol, Rc::new(data.into()))
+        FilterBlockReader::new(pol, Arc::new(data.into()))
     }
 
-    pub fn new(pol: BoxedFilterPolicy, data: Rc<BlockContents>) -> FilterBlockReader {
+    pub fn new(pol: BoxedFilterPolicy, data: Arc<BlockContents>) -> FilterBlockReader {
         assert!(data.len() >= 5);
 
         let fbase = data[data.len() - 1] as u32;
@@ -180,7 +180,7 @@ mod tests {
 
     fn produce_filter_block() -> Vec<u8> {
         let keys = get_keys();
-        let mut bld = FilterBlockBuilder::new(Rc::new(Box::new(BloomPolicy::new(32))));
+        let mut bld = FilterBlockBuilder::new(Arc::new(Box::new(BloomPolicy::new(32))));
 
         bld.start_block(0);
 
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn test_filter_block_build_read() {
         let result = produce_filter_block();
-        let reader = FilterBlockReader::new_owned(Rc::new(Box::new(BloomPolicy::new(32))), result);
+        let reader = FilterBlockReader::new_owned(Arc::new(Box::new(BloomPolicy::new(32))), result);
 
         assert_eq!(
             reader.offset_of(get_filter_index(5121, FILTER_BASE_LOG2)),

--- a/src/infolog.rs
+++ b/src/infolog.rs
@@ -1,6 +1,6 @@
-use std::io::{self, Write};
+use std::io;
 
-pub struct Logger(pub Box<dyn Write>);
+pub struct Logger(pub Box<dyn std::io::Write + Send + Sync>);
 
 pub fn stderr() -> Logger {
     Logger(Box::new(io::stderr()))
@@ -8,10 +8,10 @@ pub fn stderr() -> Logger {
 
 #[macro_export]
 macro_rules! log {
-    ($l:expr) => ($l.as_ref().map(|l| l.borrow_mut().0.write("\n".as_bytes()).is_ok()));
+    ($l:expr) => ($l.as_ref().map(|l| l.write().unwrap().0.write("\n".as_bytes()).is_ok()));
     ($l:expr, $fmt:expr) => (
-        $l.as_ref().map(|l| l.borrow_mut().0.write(concat!($fmt, "\n").as_bytes()).is_ok()));
+        $l.as_ref().map(|l| l.write().unwrap().0.write(concat!($fmt, "\n").as_bytes()).is_ok()));
     ($l:expr, $fmt:expr, $($arg:tt)*) => (
         $l.as_ref().map(
-            |l| l.borrow_mut().0.write_fmt(format_args!(concat!($fmt, "\n"), $($arg)*)).is_ok()));
+            |l| l.write().unwrap().0.write_fmt(format_args!(concat!($fmt, "\n"), $($arg)*)).is_ok()));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use asyncdb_async_std::{send_response, send_response_result, Message};
 mod block;
 mod block_builder;
 mod blockhandle;
-mod cache;
+pub mod cache;
 mod cmp;
 mod crc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,9 @@ mod asyncdb_tokio;
 #[cfg(feature = "asyncdb-tokio")]
 use asyncdb_tokio::{send_response, send_response_result, Message};
 
-#[cfg(feature = "asyncdb-async-std")]
+#[cfg(all(feature = "asyncdb-async-std", not(feature = "asyncdb-tokio")))]
 mod asyncdb_async_std;
-#[cfg(feature = "asyncdb-async-std")]
+#[cfg(all(feature = "asyncdb-async-std", not(feature = "asyncdb-tokio")))]
 use asyncdb_async_std::{send_response, send_response_result, Message};
 
 mod block;
@@ -92,7 +92,7 @@ mod db_iter;
 pub mod compressor;
 pub mod env;
 
-#[cfg(feature = "asyncdb-async-std")]
+#[cfg(all(feature = "asyncdb-async-std", not(feature = "asyncdb-tokio")))]
 pub use asyncdb_async_std::AsyncDB;
 #[cfg(feature = "asyncdb-tokio")]
 pub use asyncdb_tokio::AsyncDB;

--- a/src/log.rs
+++ b/src/log.rs
@@ -303,10 +303,10 @@ mod tests {
         loop {
             let r = lr.read(&mut dst);
 
-            if r.is_err() {
-                panic!("{}", r.unwrap_err());
-            } else if r.unwrap() == 0 {
-                break;
+            match r {
+                Err(e) => panic!("{}", e),
+                Ok(0) => break,
+                _ => {}
             }
 
             assert_eq!(dst, data[i]);

--- a/src/mem_env.rs
+++ b/src/mem_env.rs
@@ -158,7 +158,12 @@ impl MemFS {
         }
     }
     /// Open a file for writing.
-    fn open_w(&self, p: &Path, append: bool, truncate: bool) -> Result<Box<dyn Write>> {
+    fn open_w(
+        &self,
+        p: &Path,
+        append: bool,
+        truncate: bool,
+    ) -> Result<Box<dyn std::io::Write + Send + Sync>> {
         let f = self.open(p, true)?;
         if truncate {
             f.0.lock().unwrap().clear();
@@ -298,10 +303,10 @@ impl Env for MemEnv {
             .open(p, false)
             .map(|m| Box::new(m) as Box<dyn RandomAccess>)
     }
-    fn open_writable_file(&self, p: &Path) -> Result<Box<dyn Write>> {
+    fn open_writable_file(&self, p: &Path) -> Result<Box<dyn std::io::Write + Send + Sync>> {
         self.0.open_w(p, true, true)
     }
-    fn open_appendable_file(&self, p: &Path) -> Result<Box<dyn Write>> {
+    fn open_appendable_file(&self, p: &Path) -> Result<Box<dyn std::io::Write + Send + Sync>> {
         self.0.open_w(p, true, false)
     }
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -4,7 +4,7 @@ use crate::key_types::{LookupKey, UserKey};
 use crate::skipmap::{SkipMap, SkipMapIter};
 use crate::types::{current_key_val, LdbIterator, SequenceNumber};
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use integer_encoding::FixedInt;
@@ -18,12 +18,12 @@ pub struct MemTable {
 impl MemTable {
     /// Returns a new MemTable.
     /// This wraps opt.cmp inside a MemtableKey-specific comparator.
-    pub fn new(cmp: Rc<Box<dyn Cmp>>) -> MemTable {
-        MemTable::new_raw(Rc::new(Box::new(MemtableKeyCmp(cmp))))
+    pub fn new(cmp: Arc<Box<dyn Cmp>>) -> MemTable {
+        MemTable::new_raw(Arc::new(Box::new(MemtableKeyCmp(cmp))))
     }
 
     /// Doesn't wrap the comparator in a MemtableKeyCmp.
-    fn new_raw(cmp: Rc<Box<dyn Cmp>>) -> MemTable {
+    fn new_raw(cmp: Arc<Box<dyn Cmp>>) -> MemTable {
         MemTable {
             map: SkipMap::new(cmp),
         }

--- a/src/merging_iter.rs
+++ b/src/merging_iter.rs
@@ -3,7 +3,7 @@ use crate::types::{current_key_val, Direction, LdbIterator};
 
 use bytes::Bytes;
 use std::cmp::Ordering;
-use std::rc::Rc;
+use std::sync::Arc;
 
 // Warning: This module is kinda messy. The original implementation is
 // not that much better though :-)
@@ -21,12 +21,12 @@ pub struct MergingIter {
     iters: Vec<Box<dyn LdbIterator>>,
     current: Option<usize>,
     direction: Direction,
-    cmp: Rc<Box<dyn Cmp>>,
+    cmp: Arc<Box<dyn Cmp>>,
 }
 
 impl MergingIter {
     /// Construct a new merging iterator.
-    pub fn new(cmp: Rc<Box<dyn Cmp>>, iters: Vec<Box<dyn LdbIterator>>) -> MergingIter {
+    pub fn new(cmp: Arc<Box<dyn Cmp>>, iters: Vec<Box<dyn LdbIterator>>) -> MergingIter {
         MergingIter {
             iters,
             current: None,
@@ -203,7 +203,7 @@ mod tests {
         let iter = skm.iter();
         let mut iter2 = skm.iter();
 
-        let mut miter = MergingIter::new(Rc::new(Box::new(DefaultCmp)), vec![Box::new(iter)]);
+        let mut miter = MergingIter::new(Arc::new(Box::new(DefaultCmp)), vec![Box::new(iter)]);
 
         while let Some((k, v)) = miter.next() {
             if let Some((k2, v2)) = iter2.next() {
@@ -222,7 +222,7 @@ mod tests {
         let iter2 = skm.iter();
 
         let mut miter = MergingIter::new(
-            Rc::new(Box::new(DefaultCmp)),
+            Arc::new(Box::new(DefaultCmp)),
             vec![Box::new(iter), Box::new(iter2)],
         );
 
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_merging_zero() {
-        let mut miter = MergingIter::new(Rc::new(Box::new(DefaultCmp)), vec![]);
+        let mut miter = MergingIter::new(Arc::new(Box::new(DefaultCmp)), vec![]);
         assert_eq!(0, LdbIteratorIter::wrap(&mut miter).count());
     }
 
@@ -248,7 +248,7 @@ mod tests {
         let iter = TestLdbIter::new(vec![(b("aba"), val), (b("abc"), val)]);
         let iter2 = TestLdbIter::new(vec![(b("abb"), val), (b("abd"), val)]);
         let miter = MergingIter::new(
-            Rc::new(Box::new(DefaultCmp)),
+            Arc::new(Box::new(DefaultCmp)),
             vec![Box::new(iter), Box::new(iter2)],
         );
         test_iterator_properties(miter);
@@ -261,7 +261,7 @@ mod tests {
         let iter2 = TestLdbIter::new(vec![(b("abb"), val), (b("abd"), val)]);
 
         let mut miter = MergingIter::new(
-            Rc::new(Box::new(DefaultCmp)),
+            Arc::new(Box::new(DefaultCmp)),
             vec![Box::new(iter), Box::new(iter2)],
         );
 
@@ -309,7 +309,7 @@ mod tests {
         let expected = [b("aba"), b("abb"), b("abc"), b("abd"), b("abe")];
 
         let mut iter = MergingIter::new(
-            Rc::new(Box::new(DefaultCmp)),
+            Arc::new(Box::new(DefaultCmp)),
             vec![Box::new(it1), Box::new(it2)],
         );
 
@@ -326,7 +326,7 @@ mod tests {
         let it2 = TestLdbIter::new(vec![(b("abb"), val), (b("abd"), val)]);
 
         let mut iter = MergingIter::new(
-            Rc::new(Box::new(DefaultCmp)),
+            Arc::new(Box::new(DefaultCmp)),
             vec![Box::new(it1), Box::new(it2)],
         );
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -8,7 +8,7 @@ use crate::Result;
 use crate::{filter, Status, StatusCode};
 
 use std::default::Default;
-use std::rc::Rc;
+use std::sync::Arc;
 
 const KB: usize = 1 << 10;
 const MB: usize = KB * KB;
@@ -22,8 +22,8 @@ const DEFAULT_BITS_PER_KEY: u32 = 10; // NOTE: This may need to be optimized.
 /// self-explanatory; the defaults are defined in the `Default` implementation.
 #[derive(Clone)]
 pub struct Options {
-    pub cmp: Rc<Box<dyn Cmp>>,
-    pub env: Rc<Box<dyn Env>>,
+    pub cmp: Arc<Box<dyn Cmp>>,
+    pub env: Arc<Box<dyn Env>>,
     pub log: Option<Shared<Logger>>,
     pub create_if_missing: bool,
     pub error_if_exists: bool,
@@ -37,7 +37,7 @@ pub struct Options {
     /// Compressor id in CompressorList
     pub compressor: u8,
 
-    pub compressor_list: Rc<CompressorList>,
+    pub compressor_list: Arc<CompressorList>,
     pub reuse_logs: bool,
     pub reuse_manifest: bool,
     pub filter_policy: filter::BoxedFilterPolicy,
@@ -52,8 +52,8 @@ type DefaultEnv = crate::mem_env::MemEnv;
 impl Default for Options {
     fn default() -> Options {
         Options {
-            cmp: Rc::new(Box::new(DefaultCmp)),
-            env: Rc::new(Box::new(DefaultEnv::new())),
+            cmp: Arc::new(Box::new(DefaultCmp)),
+            env: Arc::new(Box::new(DefaultEnv::new())),
             log: None,
             create_if_missing: true,
             error_if_exists: false,
@@ -67,8 +67,8 @@ impl Default for Options {
             reuse_logs: true,
             reuse_manifest: true,
             compressor: 0,
-            compressor_list: Rc::new(CompressorList::default()),
-            filter_policy: Rc::new(Box::new(filter::BloomPolicy::new(DEFAULT_BITS_PER_KEY))),
+            compressor_list: Arc::new(CompressorList::default()),
+            filter_policy: Arc::new(Box::new(filter::BloomPolicy::new(DEFAULT_BITS_PER_KEY))),
         }
     }
 }
@@ -132,14 +132,14 @@ impl Default for CompressorList {
 /// disk. This is useful for testing or ephemeral databases.
 pub fn in_memory() -> Options {
     Options {
-        env: Rc::new(Box::new(MemEnv::new())),
+        env: Arc::new(Box::new(MemEnv::new())),
         ..Options::default()
     }
 }
 
 pub fn for_test() -> Options {
     Options {
-        env: Rc::new(Box::new(MemEnv::new())),
+        env: Arc::new(Box::new(MemEnv::new())),
         log: Some(share(infolog::stderr())),
         ..Options::default()
     }

--- a/src/skipmap.rs
+++ b/src/skipmap.rs
@@ -4,10 +4,10 @@ use crate::rand::{RngCore, SeedableRng};
 use crate::types::LdbIterator;
 
 use bytes::Bytes;
-use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::mem::size_of;
-use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::RwLock;
 
 const MAX_HEIGHT: usize = 12;
 const BRANCHING_FACTOR: u32 = 4;
@@ -31,7 +31,7 @@ struct InnerSkipMap {
     len: usize,
     // approximation of memory used.
     approx_mem: usize,
-    cmp: Rc<Box<dyn Cmp>>,
+    cmp: Arc<Box<dyn Cmp>>,
 }
 
 impl Drop for InnerSkipMap {
@@ -45,22 +45,22 @@ impl Drop for InnerSkipMap {
 }
 
 pub struct SkipMap {
-    map: Rc<RefCell<InnerSkipMap>>,
+    map: Arc<RwLock<InnerSkipMap>>,
 }
 
 impl SkipMap {
     /// Returns a SkipMap that wraps the comparator inside a MemtableKeyCmp.
-    pub fn new_memtable_map(cmp: Rc<Box<dyn Cmp>>) -> SkipMap {
-        SkipMap::new(Rc::new(Box::new(MemtableKeyCmp(cmp))))
+    pub fn new_memtable_map(cmp: Arc<Box<dyn Cmp>>) -> SkipMap {
+        SkipMap::new(Arc::new(Box::new(MemtableKeyCmp(cmp))))
     }
 
     /// Returns a SkipMap that uses the specified comparator.
-    pub fn new(cmp: Rc<Box<dyn Cmp>>) -> SkipMap {
+    pub fn new(cmp: Arc<Box<dyn Cmp>>) -> SkipMap {
         let mut s = Vec::new();
         s.resize(MAX_HEIGHT, None);
 
         SkipMap {
-            map: Rc::new(RefCell::new(InnerSkipMap {
+            map: Arc::new(RwLock::new(InnerSkipMap {
                 head: Box::new(Node {
                     skips: s,
                     next: None,
@@ -76,7 +76,7 @@ impl SkipMap {
     }
 
     pub fn len(&self) -> usize {
-        self.map.borrow().len
+        self.map.read().unwrap().len
     }
 
     #[must_use]
@@ -85,23 +85,23 @@ impl SkipMap {
     }
 
     pub fn approx_memory(&self) -> usize {
-        self.map.borrow().approx_mem
+        self.map.read().unwrap().approx_mem
     }
 
     pub fn contains(&self, key: &[u8]) -> bool {
-        self.map.borrow().contains(key)
+        self.map.read().unwrap().contains(key)
     }
 
     /// inserts a key into the table. key may not be empty.
     pub fn insert(&mut self, key: Vec<u8>, val: Vec<u8>) {
         assert!(!key.is_empty());
-        self.map.borrow_mut().insert(key, val);
+        self.map.write().unwrap().insert(key, val);
     }
 
     pub fn iter(&self) -> SkipMapIter {
         SkipMapIter {
             map: self.map.clone(),
-            current: self.map.borrow().head.as_ref() as *const Node,
+            current: self.map.read().unwrap().head.as_ref() as *const Node,
         }
     }
 }
@@ -301,7 +301,7 @@ impl InnerSkipMap {
 }
 
 pub struct SkipMapIter {
-    map: Rc<RefCell<InnerSkipMap>>,
+    map: Arc<RwLock<InnerSkipMap>>,
     current: *const Node,
 }
 
@@ -324,17 +324,17 @@ impl LdbIterator for SkipMapIter {
         r
     }
     fn reset(&mut self) {
-        self.current = self.map.borrow().head.as_ref();
+        self.current = self.map.read().unwrap().head.as_ref();
     }
     fn seek(&mut self, key: &[u8]) {
-        if let Some(node) = self.map.borrow().get_greater_or_equal(key) {
+        if let Some(node) = self.map.read().unwrap().get_greater_or_equal(key) {
             self.current = node as *const Node;
             return;
         }
         self.reset();
     }
     fn valid(&self) -> bool {
-        self.current != self.map.borrow().head.as_ref()
+        self.current != self.map.read().unwrap().head.as_ref()
     }
     fn current(&self) -> Option<(Bytes, Bytes)> {
         if self.valid() {
@@ -353,7 +353,8 @@ impl LdbIterator for SkipMapIter {
         if self.valid() {
             if let Some(prev) = self
                 .map
-                .borrow()
+                .read()
+                .unwrap()
                 .get_next_smaller(unsafe { &(*self.current).key })
             {
                 self.current = prev as *const Node;
@@ -368,6 +369,9 @@ impl LdbIterator for SkipMapIter {
 }
 
 #[cfg(test)]
+unsafe impl Send for SkipMap {}
+unsafe impl Sync for SkipMap {}
+
 pub mod tests {
     use super::*;
     use crate::cmp::MemtableKeyCmp;
@@ -393,7 +397,7 @@ pub mod tests {
     fn test_insert() {
         let skm = make_skipmap();
         assert_eq!(skm.len(), 26);
-        skm.map.borrow().dbg_print();
+        skm.map.read().unwrap().dbg_print();
     }
 
     #[test]
@@ -421,29 +425,70 @@ pub mod tests {
     fn test_find() {
         let skm = make_skipmap();
         assert_eq!(
-            &*skm.map.borrow().get_greater_or_equal(b"abf").unwrap().key,
+            &*skm
+                .map
+                .read()
+                .unwrap()
+                .get_greater_or_equal(b"abf")
+                .unwrap()
+                .key,
             b"abf"
         );
-        assert!(skm.map.borrow().get_greater_or_equal(b"ab{").is_none());
+        assert!(skm
+            .map
+            .read()
+            .unwrap()
+            .get_greater_or_equal(b"ab{")
+            .is_none());
         assert_eq!(
-            &*skm.map.borrow().get_greater_or_equal(b"aaa").unwrap().key,
+            &*skm
+                .map
+                .read()
+                .unwrap()
+                .get_greater_or_equal(b"aaa")
+                .unwrap()
+                .key,
             b"aba"
         );
         assert_eq!(
-            &*skm.map.borrow().get_greater_or_equal(b"ab").unwrap().key,
+            &*skm
+                .map
+                .read()
+                .unwrap()
+                .get_greater_or_equal(b"ab")
+                .unwrap()
+                .key,
             b"aba"
         );
         assert_eq!(
-            &*skm.map.borrow().get_greater_or_equal(b"abc").unwrap().key,
+            &*skm
+                .map
+                .read()
+                .unwrap()
+                .get_greater_or_equal(b"abc")
+                .unwrap()
+                .key,
             b"abc"
         );
-        assert!(skm.map.borrow().get_next_smaller(b"ab0").is_none());
+        assert!(skm.map.read().unwrap().get_next_smaller(b"ab0").is_none());
         assert_eq!(
-            &*skm.map.borrow().get_next_smaller(b"abd").unwrap().key,
+            &*skm
+                .map
+                .read()
+                .unwrap()
+                .get_next_smaller(b"abd")
+                .unwrap()
+                .key,
             b"abc"
         );
         assert_eq!(
-            &*skm.map.borrow().get_next_smaller(b"ab{").unwrap().key,
+            &*skm
+                .map
+                .read()
+                .unwrap()
+                .get_next_smaller(b"ab{")
+                .unwrap()
+                .key,
             b"abz"
         );
     }
@@ -451,7 +496,7 @@ pub mod tests {
     #[test]
     fn test_empty_skipmap_find_memtable_cmp() {
         // Regression test: Make sure comparator isn't called with empty key.
-        let cmp: Rc<Box<dyn Cmp>> = Rc::new(Box::new(MemtableKeyCmp(options::for_test().cmp)));
+        let cmp: Arc<Box<dyn Cmp>> = Arc::new(Box::new(MemtableKeyCmp(options::for_test().cmp)));
         let skm = SkipMap::new(cmp);
 
         let mut it = skm.iter();

--- a/src/skipmap.rs
+++ b/src/skipmap.rs
@@ -13,10 +13,9 @@ const MAX_HEIGHT: usize = 12;
 const BRANCHING_FACTOR: u32 = 4;
 
 /// A node in a skipmap contains links to the next node and others that are further away (skips);
-/// `skips[0]` is the immediate element after, that is, the element contained in `next`.
+/// `skips[0]` is the immediate element after.
 struct Node {
-    skips: Vec<Option<*mut Node>>,
-    next: Option<Box<Node>>,
+    skips: [Option<usize>; MAX_HEIGHT],
     key: Bytes,
     value: Bytes,
 }
@@ -26,22 +25,13 @@ struct Node {
 /// `seek()` to the key to look up (this is as fast as any lookup in a skip map), and then call
 /// `current()`.
 struct InnerSkipMap {
-    head: Box<Node>,
+    nodes: Vec<Node>,
+    head: usize,
     rand: StdRng,
     len: usize,
     // approximation of memory used.
     approx_mem: usize,
     cmp: Arc<Box<dyn Cmp>>,
-}
-
-impl Drop for InnerSkipMap {
-    // Avoid possible stack overflow caused by dropping many nodes.
-    fn drop(&mut self) {
-        let mut next_node = self.head.next.take();
-        while let Some(mut boxed_node) = next_node {
-            next_node = boxed_node.next.take();
-        }
-    }
 }
 
 pub struct SkipMap {
@@ -56,20 +46,19 @@ impl SkipMap {
 
     /// Returns a SkipMap that uses the specified comparator.
     pub fn new(cmp: Arc<Box<dyn Cmp>>) -> SkipMap {
-        let mut s = Vec::new();
-        s.resize(MAX_HEIGHT, None);
+        let head_node = Node {
+            skips: [None; MAX_HEIGHT],
+            key: Bytes::new(),
+            value: Bytes::new(),
+        };
 
         SkipMap {
             map: Arc::new(RwLock::new(InnerSkipMap {
-                head: Box::new(Node {
-                    skips: s,
-                    next: None,
-                    key: Bytes::new(),
-                    value: Bytes::new(),
-                }),
+                nodes: vec![head_node],
+                head: 0,
                 rand: StdRng::seed_from_u64(0xdeadbeef),
                 len: 0,
-                approx_mem: size_of::<Self>() + MAX_HEIGHT * size_of::<Option<*mut Node>>(),
+                approx_mem: size_of::<Self>() + size_of::<InnerSkipMap>() + size_of::<Node>(),
                 cmp,
             })),
         }
@@ -92,7 +81,7 @@ impl SkipMap {
         self.map.read().unwrap().contains(key)
     }
 
-    /// inserts a key into the table. key may not be empty.
+    /// Inserts a key into the table. `key` may not be empty.
     pub fn insert(&mut self, key: Vec<u8>, val: Vec<u8>) {
         assert!(!key.is_empty());
         self.map.write().unwrap().insert(key, val);
@@ -101,7 +90,7 @@ impl SkipMap {
     pub fn iter(&self) -> SkipMapIter {
         SkipMapIter {
             map: self.map.clone(),
-            current: self.map.read().unwrap().head.as_ref() as *const Node,
+            current: 0, // head
         }
     }
 }
@@ -109,17 +98,15 @@ impl SkipMap {
 impl InnerSkipMap {
     fn random_height(&mut self) -> usize {
         let mut height = 1;
-
         while height < MAX_HEIGHT && self.rand.next_u32().is_multiple_of(BRANCHING_FACTOR) {
             height += 1;
         }
-
         height
     }
 
     fn contains(&self, key: &[u8]) -> bool {
-        if let Some(n) = self.get_greater_or_equal(key) {
-            n.key.starts_with(key)
+        if let Some(n_idx) = self.get_greater_or_equal(key) {
+            self.nodes[n_idx].key.starts_with(key)
         } else {
             false
         }
@@ -127,16 +114,14 @@ impl InnerSkipMap {
 
     /// Returns the node with key or the next greater one
     /// Returns None if the given key lies past the greatest key in the table.
-    fn get_greater_or_equal<'a>(&'a self, key: &[u8]) -> Option<&'a Node> {
+    fn get_greater_or_equal(&self, key: &[u8]) -> Option<usize> {
         // Start at the highest skip link of the head node, and work down from there
-        let mut current = self.head.as_ref() as *const Node;
-        let mut level = self.head.skips.len() - 1;
+        let mut current = self.head;
+        let mut level = self.nodes[self.head].skips.len() - 1;
 
         loop {
-            let current_node = unsafe { &*current };
-            if let Some(next) = current_node.skips[level] {
-                let next = unsafe { &*next };
-                let ord = self.cmp.cmp(next.key.iter().as_slice(), key);
+            if let Some(next) = self.nodes[current].skips[level] {
+                let ord = self.cmp.cmp(self.nodes[next].key.iter().as_slice(), key);
 
                 match ord {
                     Ordering::Less => {
@@ -157,29 +142,23 @@ impl InnerSkipMap {
             level -= 1;
         }
 
-        unsafe {
-            if (current.is_null() || current == self.head.as_ref())
-                || (self.cmp.cmp(&(*current).key, key) == Ordering::Less)
-            {
-                None
-            } else {
-                Some(&(*current))
-            }
+        if current == self.head || self.cmp.cmp(&self.nodes[current].key, key) == Ordering::Less {
+            None
+        } else {
+            Some(current)
         }
     }
 
     /// Finds the node immediately before the node with key.
     /// Returns None if no smaller key was found.
-    fn get_next_smaller<'a>(&'a self, key: &[u8]) -> Option<&'a Node> {
+    fn get_next_smaller(&self, key: &[u8]) -> Option<usize> {
         // Start at the highest skip link of the head node, and work down from there
-        let mut current = self.head.as_ref() as *const Node;
-        let mut level = self.head.skips.len() - 1;
+        let mut current = self.head;
+        let mut level = self.nodes[self.head].skips.len() - 1;
 
         loop {
-            let current_node = unsafe { &*current };
-            if let Some(next) = current_node.skips[level] {
-                let next = unsafe { &*next };
-                let ord = self.cmp.cmp(next.key.iter().as_slice(), key);
+            if let Some(next) = self.nodes[current].skips[level] {
+                let ord = self.cmp.cmp(self.nodes[next].key.iter().as_slice(), key);
 
                 if let Ordering::Less = ord {
                     current = next;
@@ -193,15 +172,13 @@ impl InnerSkipMap {
             level -= 1;
         }
 
-        unsafe {
-            if current.is_null() || current == self.head.as_ref() {
-                // If we're past the end for some reason or at the head
-                None
-            } else if self.cmp.cmp(&(*current).key, key) != Ordering::Less {
-                None
-            } else {
-                Some(&(*current))
-            }
+        if current == self.head {
+            // If we're past the end for some reason or at the head
+            None
+        } else if self.cmp.cmp(&self.nodes[current].key, key) != Ordering::Less {
+            None
+        } else {
+            Some(current)
         }
     }
 
@@ -209,26 +186,23 @@ impl InnerSkipMap {
         assert!(!key.is_empty());
 
         // Keeping track of skip entries that will need to be updated
-        let mut prevs: [Option<*mut Node>; MAX_HEIGHT] = [None; MAX_HEIGHT];
+        let mut prevs = [0; MAX_HEIGHT];
         let new_height = self.random_height();
-        let prevs = &mut prevs[0..new_height];
 
         let mut level = MAX_HEIGHT - 1;
-        let mut current = self.head.as_mut() as *mut Node;
+        let mut current = self.head;
+
         // Set previous node for all levels to current node.
-        (0..prevs.len()).for_each(|i| {
-            prevs[i] = Some(current);
-        });
+        for prev in prevs.iter_mut().take(new_height) {
+            *prev = current;
+        }
 
         // Find the node after which we want to insert the new node; this is the node with the key
         // immediately smaller than the key to be inserted.
         loop {
-            let current_node = unsafe { &*current };
-            if let Some(next) = current_node.skips[level] {
-                let next = unsafe { &mut *next };
+            if let Some(next) = self.nodes[current].skips[level] {
                 // If the wanted position is after the current node
-                let ord = self.cmp.cmp(next.key.iter().as_slice(), &key);
-
+                let ord = self.cmp.cmp(self.nodes[next].key.iter().as_slice(), &key);
                 assert!(ord != Ordering::Equal, "No duplicates allowed");
 
                 if ord == Ordering::Less {
@@ -238,7 +212,7 @@ impl InnerSkipMap {
             }
 
             if level < new_height {
-                prevs[level] = Some(current);
+                prevs[level] = current;
             }
 
             if level == 0 {
@@ -249,46 +223,36 @@ impl InnerSkipMap {
         }
 
         // Construct new node
-        let mut new_skips = Vec::new();
-        new_skips.resize(new_height, None);
-        let mut new = Box::new(Node {
-            skips: new_skips,
-            next: None,
+        let new_idx = self.nodes.len();
+
+        let new_node = Node {
+            skips: [None; MAX_HEIGHT],
             key: key.into(),
             value: val.into(),
-        });
-        let newp = new.as_mut() as *mut Node;
+        };
 
-        (0..new_height).for_each(|i| {
-            if let Some(prev) = prevs[i] {
-                let prev = unsafe { &mut *prev };
-                new.skips[i] = prev.skips[i];
-                prev.skips[i] = Some(newp);
-            }
-        });
-
-        let added_mem = size_of::<Node>()
-            + size_of::<Option<*mut Node>>() * new.skips.len()
-            + new.key.len()
-            + new.value.len();
+        let added_mem = size_of::<Node>() + new_node.key.len() + new_node.value.len();
         self.approx_mem += added_mem;
         self.len += 1;
 
+        self.nodes.push(new_node);
+
         // Insert new node by first replacing the previous element's next field with None and
         // assigning its value to new.next...
-        new.next = unsafe { (*current).next.take() };
         // ...and then setting the previous element's next field to the new node
-        unsafe {
-            let _ = (*current).next.replace(new);
-        };
+        for (i, &prev) in prevs.iter().enumerate().take(new_height) {
+            self.nodes[new_idx].skips[i] = self.nodes[prev].skips[i];
+            self.nodes[prev].skips[i] = Some(new_idx);
+        }
     }
-    /// Runs through the skipmap and prints everything including addresses
+
+    /// Runs through the skipmap and prints everything including indices
     fn dbg_print(&self) {
-        let mut current = self.head.as_ref() as *const Node;
+        let mut current = self.head;
         loop {
-            let current_node = unsafe { &*current };
+            let current_node = &self.nodes[current];
             eprintln!(
-                "{:?} {:?}/{:?} - {:?}",
+                "{} {:?}/{:?} - {:?}",
                 current, current_node.key, current_node.value, current_node.skips
             );
             if let Some(next) = current_node.skips[0] {
@@ -302,21 +266,20 @@ impl InnerSkipMap {
 
 pub struct SkipMapIter {
     map: Arc<RwLock<InnerSkipMap>>,
-    current: *const Node,
+    current: usize,
 }
 
 impl LdbIterator for SkipMapIter {
     fn advance(&mut self) -> bool {
         // we first go to the next element, then return that -- in order to skip the head node
-        let r = unsafe {
-            (*self.current)
-                .next
-                .as_ref()
-                .map(|next| {
-                    self.current = next.as_ref() as *const Node;
-                    true
-                })
-                .unwrap_or(false)
+        let r = {
+            let map = self.map.read().unwrap();
+            if let Some(next) = map.nodes[self.current].skips[0] {
+                self.current = next;
+                true
+            } else {
+                false
+            }
         };
         if !r {
             self.reset();
@@ -324,41 +287,39 @@ impl LdbIterator for SkipMapIter {
         r
     }
     fn reset(&mut self) {
-        self.current = self.map.read().unwrap().head.as_ref();
+        self.current = self.map.read().unwrap().head;
     }
     fn seek(&mut self, key: &[u8]) {
-        if let Some(node) = self.map.read().unwrap().get_greater_or_equal(key) {
-            self.current = node as *const Node;
+        let map = self.map.read().unwrap();
+        if let Some(node_idx) = map.get_greater_or_equal(key) {
+            self.current = node_idx;
             return;
         }
+        drop(map);
         self.reset();
     }
     fn valid(&self) -> bool {
-        self.current != self.map.read().unwrap().head.as_ref()
+        self.current != self.map.read().unwrap().head
     }
     fn current(&self) -> Option<(Bytes, Bytes)> {
         if self.valid() {
-            unsafe {
-                Some((
-                    Bytes::copy_from_slice(&(*self.current).key),
-                    Bytes::copy_from_slice(&(*self.current).value),
-                ))
-            }
+            let map = self.map.read().unwrap();
+            let node = &map.nodes[self.current];
+            Some((
+                Bytes::copy_from_slice(&node.key),
+                Bytes::copy_from_slice(&node.value),
+            ))
         } else {
             None
         }
     }
     fn prev(&mut self) -> bool {
-        // Going after the original implementation here; we just seek to the node before current().
         if self.valid() {
-            if let Some(prev) = self
-                .map
-                .read()
-                .unwrap()
-                .get_next_smaller(unsafe { &(*self.current).key })
-            {
-                self.current = prev as *const Node;
-                if !prev.key.is_empty() {
+            // Going after the original implementation here; we just seek to the node before current().
+            let map = self.map.read().unwrap();
+            if let Some(prev_idx) = map.get_next_smaller(&map.nodes[self.current].key) {
+                self.current = prev_idx;
+                if !map.nodes[prev_idx].key.is_empty() {
                     return true;
                 }
             }
@@ -369,9 +330,6 @@ impl LdbIterator for SkipMapIter {
 }
 
 #[cfg(test)]
-unsafe impl Send for SkipMap {}
-unsafe impl Sync for SkipMap {}
-
 pub mod tests {
     use super::*;
     use crate::cmp::MemtableKeyCmp;
@@ -388,7 +346,7 @@ pub mod tests {
         ];
 
         for k in keys {
-            skm.insert(k.as_bytes().to_vec(), "def".as_bytes().to_vec());
+            skm.insert(k.as_bytes().to_vec(), b"def".to_vec());
         }
         skm
     }
@@ -405,8 +363,8 @@ pub mod tests {
     fn test_no_dupes() {
         let mut skm = make_skipmap();
         // this should panic
-        skm.insert("abc".as_bytes().to_vec(), "def".as_bytes().to_vec());
-        skm.insert("abf".as_bytes().to_vec(), "def".as_bytes().to_vec());
+        skm.insert(b"abc".to_vec(), b"def".to_vec());
+        skm.insert(b"abf".to_vec(), b"def".to_vec());
     }
 
     #[test]
@@ -425,13 +383,14 @@ pub mod tests {
     fn test_find() {
         let skm = make_skipmap();
         assert_eq!(
-            &*skm
+            skm.map.read().unwrap().nodes[skm
                 .map
                 .read()
                 .unwrap()
                 .get_greater_or_equal(b"abf")
-                .unwrap()
-                .key,
+                .unwrap()]
+            .key
+            .as_ref(),
             b"abf"
         );
         assert!(skm
@@ -441,54 +400,47 @@ pub mod tests {
             .get_greater_or_equal(b"ab{")
             .is_none());
         assert_eq!(
-            &*skm
+            skm.map.read().unwrap().nodes[skm
                 .map
                 .read()
                 .unwrap()
                 .get_greater_or_equal(b"aaa")
-                .unwrap()
-                .key,
+                .unwrap()]
+            .key
+            .as_ref(),
             b"aba"
         );
         assert_eq!(
-            &*skm
-                .map
-                .read()
-                .unwrap()
-                .get_greater_or_equal(b"ab")
-                .unwrap()
-                .key,
+            skm.map.read().unwrap().nodes
+                [skm.map.read().unwrap().get_greater_or_equal(b"ab").unwrap()]
+            .key
+            .as_ref(),
             b"aba"
         );
         assert_eq!(
-            &*skm
+            skm.map.read().unwrap().nodes[skm
                 .map
                 .read()
                 .unwrap()
                 .get_greater_or_equal(b"abc")
-                .unwrap()
-                .key,
+                .unwrap()]
+            .key
+            .as_ref(),
             b"abc"
         );
         assert!(skm.map.read().unwrap().get_next_smaller(b"ab0").is_none());
         assert_eq!(
-            &*skm
-                .map
-                .read()
-                .unwrap()
-                .get_next_smaller(b"abd")
-                .unwrap()
-                .key,
+            skm.map.read().unwrap().nodes
+                [skm.map.read().unwrap().get_next_smaller(b"abd").unwrap()]
+            .key
+            .as_ref(),
             b"abc"
         );
         assert_eq!(
-            &*skm
-                .map
-                .read()
-                .unwrap()
-                .get_next_smaller(b"ab{")
-                .unwrap()
-                .key,
+            skm.map.read().unwrap().nodes
+                [skm.map.read().unwrap().get_next_smaller(b"ab{").unwrap()]
+            .key
+            .as_ref(),
             b"abz"
         );
     }
@@ -554,11 +506,11 @@ pub mod tests {
 
         iter.next();
         assert!(iter.valid());
-        assert_eq!(current_key_val(&iter).unwrap().0, "aba".as_bytes().to_vec());
+        assert_eq!(current_key_val(&iter).unwrap().0, b"aba".to_vec());
         iter.seek(b"abz");
         assert_eq!(
             current_key_val(&iter).unwrap(),
-            ("abz".as_bytes().to_vec(), "def".as_bytes().to_vec())
+            (b"abz".to_vec(), b"def".to_vec())
         );
         // go back to beginning
         iter.seek(b"aba");
@@ -583,7 +535,7 @@ pub mod tests {
         let mut skm = SkipMap::new(options::for_test().cmp);
         let keys = vec!["aba", "abb", "abc", "abd"];
         for k in keys {
-            skm.insert(k.as_bytes().to_vec(), "def".as_bytes().to_vec());
+            skm.insert(k.as_bytes().to_vec(), b"def".to_vec());
         }
         test_iterator_properties(skm.iter());
     }
@@ -601,7 +553,7 @@ pub mod tests {
         iter.prev();
         assert_eq!(
             current_key_val(&iter).unwrap(),
-            ("abb".as_bytes().to_vec(), "def".as_bytes().to_vec())
+            (b"abb".to_vec(), b"def".to_vec())
         );
     }
 
@@ -613,10 +565,10 @@ pub mod tests {
         let mut iter = skm.iter();
 
         assert!(iter.advance());
-        skm.insert("abccc".as_bytes().to_vec(), "defff".as_bytes().to_vec());
+        skm.insert(b"abccc".to_vec(), b"defff".to_vec());
         // Assert that value inserted after obtaining iterator is present.
         for (k, _) in LdbIteratorIter::wrap(&mut iter) {
-            if k == "abccc".as_bytes() {
+            if k == b"abccc" {
                 return;
             }
         }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::types::{share, SequenceNumber, Shared, MAX_SEQUENCE_NUMBER};
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Opaque snapshot handle; Represents index to SnapshotList.map
 type SnapshotHandle = u64;
@@ -18,13 +18,13 @@ struct InnerSnapshot {
 
 impl Drop for InnerSnapshot {
     fn drop(&mut self) {
-        self.sl.borrow_mut().delete(self.id);
+        self.sl.write().unwrap().delete(self.id);
     }
 }
 
 #[derive(Clone)]
 pub struct Snapshot {
-    inner: Rc<InnerSnapshot>,
+    inner: Arc<InnerSnapshot>,
 }
 
 impl Snapshot {
@@ -57,7 +57,7 @@ impl SnapshotList {
 
     pub fn new_snapshot(&mut self, seq: SequenceNumber) -> Snapshot {
         let inner = self.inner.clone();
-        let mut sl = self.inner.borrow_mut();
+        let mut sl = self.inner.write().unwrap();
 
         sl.newest += 1;
         let newest = sl.newest;
@@ -68,7 +68,7 @@ impl SnapshotList {
         }
 
         Snapshot {
-            inner: Rc::new(InnerSnapshot {
+            inner: Arc::new(InnerSnapshot {
                 id: sl.newest,
                 seq,
                 sl: inner,
@@ -79,15 +79,16 @@ impl SnapshotList {
     /// oldest returns the lowest sequence number of all snapshots. It returns 0 if no snapshots
     /// are present.
     pub fn oldest(&self) -> SequenceNumber {
-        let oldest = self
-            .inner
-            .borrow()
-            .map
-            .iter()
-            .fold(
-                MAX_SEQUENCE_NUMBER,
-                |s, (seq, _)| if *seq < s { *seq } else { s },
-            );
+        let oldest =
+            self.inner
+                .read()
+                .unwrap()
+                .map
+                .iter()
+                .fold(
+                    MAX_SEQUENCE_NUMBER,
+                    |s, (seq, _)| if *seq < s { *seq } else { s },
+                );
         if oldest == MAX_SEQUENCE_NUMBER {
             0
         } else {
@@ -99,14 +100,15 @@ impl SnapshotList {
     /// returns 0.
     pub fn newest(&self) -> SequenceNumber {
         self.inner
-            .borrow()
+            .read()
+            .unwrap()
             .map
             .iter()
             .fold(0, |s, (seq, _)| if *seq > s { *seq } else { s })
     }
 
     pub fn empty(&self) -> bool {
-        self.inner.borrow().oldest == 0
+        self.inner.read().unwrap().oldest == 0
     }
 }
 

--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -13,7 +13,7 @@ use crate::options::Options;
 
 use std::cmp::Ordering;
 use std::io::Write;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use integer_encoding::FixedIntWriter;
 
@@ -94,7 +94,7 @@ pub struct TableBuilder<Dst: Write> {
 
 impl<Dst: Write> TableBuilder<Dst> {
     pub fn new_no_filter(mut opt: Options, dst: Dst) -> TableBuilder<Dst> {
-        opt.filter_policy = Rc::new(Box::new(NoFilterPolicy::new()));
+        opt.filter_policy = Arc::new(Box::new(NoFilterPolicy::new()));
         TableBuilder::new(opt, dst)
     }
 }
@@ -106,8 +106,8 @@ impl<Dst: Write> TableBuilder<Dst> {
     /// The comparator in opt will be wrapped in a InternalKeyCmp, and the filter policy
     /// in an InternalFilterPolicy.
     pub fn new(mut opt: Options, dst: Dst) -> TableBuilder<Dst> {
-        opt.cmp = Rc::new(Box::new(InternalKeyCmp(opt.cmp.clone())));
-        opt.filter_policy = Rc::new(Box::new(InternalFilterPolicy::new(opt.filter_policy)));
+        opt.cmp = Arc::new(Box::new(InternalKeyCmp(opt.cmp.clone())));
+        opt.filter_policy = Arc::new(Box::new(InternalFilterPolicy::new(opt.filter_policy)));
         TableBuilder::new_raw(opt, dst)
     }
 

--- a/src/table_cache.rs
+++ b/src/table_cache.rs
@@ -15,7 +15,7 @@ use integer_encoding::FixedIntWriter;
 use bytes::Bytes;
 use std::convert::AsRef;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub fn table_file_name<P: AsRef<Path>>(name: P, num: FileNum) -> PathBuf {
     assert!(num > 0);
@@ -30,7 +30,7 @@ fn filenum_to_key(num: FileNum) -> cache::CacheKey {
 
 pub struct TableCache {
     dbname: PathBuf,
-    cache: Cache<Table>,
+    cache: std::sync::Mutex<Cache<Table>>,
     block_cache: Shared<Cache<Block>>,
     opts: Options,
 }
@@ -47,47 +47,52 @@ impl TableCache {
     ) -> TableCache {
         TableCache {
             dbname: db.as_ref().to_owned(),
-            cache: Cache::new(entries),
+            cache: std::sync::Mutex::new(Cache::new(entries)),
             block_cache,
             opts: opt,
         }
     }
 
-    pub fn get(
-        &mut self,
-        file_num: FileNum,
-        key: InternalKey<'_>,
-    ) -> Result<Option<(Bytes, Bytes)>> {
+    pub fn get(&self, file_num: FileNum, key: InternalKey<'_>) -> Result<Option<(Bytes, Bytes)>> {
         let tbl = self.get_table(file_num)?;
         tbl.get(key)
     }
 
     /// Return a table from cache, or open the backing file, then cache and return it.
-    pub fn get_table(&mut self, file_num: FileNum) -> Result<Table> {
+    pub fn get_table(&self, file_num: FileNum) -> Result<Table> {
         let key = filenum_to_key(file_num);
-        if let Some(t) = self.cache.get(&key) {
+        if let Some(t) = self.cache.lock().unwrap().get(&key) {
             return Ok(t.clone());
         }
         self.open_table(file_num)
     }
 
     /// Open a table on the file system and read it.
-    fn open_table(&mut self, file_num: FileNum) -> Result<Table> {
+    fn open_table(&self, file_num: FileNum) -> Result<Table> {
         let name = table_file_name(&self.dbname, file_num);
         let path = Path::new(&name);
         let file_size = self.opts.env.size_of(path)?;
         if file_size == 0 {
             return err(StatusCode::InvalidData, "file is empty");
         }
-        let file = Rc::new(self.opts.env.open_random_access_file(path)?);
+        let file = Arc::new(self.opts.env.open_random_access_file(path)?);
         // No SSTable file name compatibility.
         let table = Table::new(self.opts.clone(), self.block_cache.clone(), file, file_size)?;
-        self.cache.insert(&filenum_to_key(file_num), table.clone());
+        self.cache
+            .lock()
+            .unwrap()
+            .insert(&filenum_to_key(file_num), table.clone());
         Ok(table)
     }
 
-    pub fn evict(&mut self, file_num: FileNum) -> Result<()> {
-        if self.cache.remove(&filenum_to_key(file_num)).is_some() {
+    pub fn evict(&self, file_num: FileNum) -> Result<()> {
+        if self
+            .cache
+            .lock()
+            .unwrap()
+            .remove(&filenum_to_key(file_num))
+            .is_some()
+        {
             Ok(())
         } else {
             err(StatusCode::NotFound, "table not present in cache")
@@ -147,7 +152,7 @@ mod tests {
         // Tests that a table can be written to a MemFS file, read back by the table cache and
         // parsed/iterated by the table reader.
         let mut opt = options::for_test();
-        opt.env = Rc::new(Box::new(MemEnv::new()));
+        opt.env = Arc::new(Box::new(MemEnv::new()));
         let bc = share(Cache::new(128));
         let dbname = Path::new("testdb1");
         let tablename = table_file_name(dbname, 123);
@@ -157,8 +162,13 @@ mod tests {
         assert!(opt.env.exists(tblpath).unwrap());
         assert!(opt.env.size_of(tblpath).unwrap() > 20);
 
-        let mut cache = TableCache::new(dbname, opt.clone(), bc, 10);
-        assert!(cache.cache.get(&filenum_to_key(123)).is_none());
+        let cache = TableCache::new(dbname, opt.clone(), bc, 10);
+        assert!(cache
+            .cache
+            .lock()
+            .unwrap()
+            .get(&filenum_to_key(123))
+            .is_none());
         assert_eq!(
             LdbIteratorIter::wrap(&mut cache.get_table(123).unwrap().iter()).count(),
             4
@@ -169,9 +179,19 @@ mod tests {
             4
         );
 
-        assert!(cache.cache.get(&filenum_to_key(123)).is_some());
+        assert!(cache
+            .cache
+            .lock()
+            .unwrap()
+            .get(&filenum_to_key(123))
+            .is_some());
         assert!(cache.evict(123).is_ok());
         assert!(cache.evict(123).is_err());
-        assert!(cache.cache.get(&filenum_to_key(123)).is_none());
+        assert!(cache
+            .cache
+            .lock()
+            .unwrap()
+            .get(&filenum_to_key(123))
+            .is_none());
     }
 }

--- a/src/table_reader.rs
+++ b/src/table_reader.rs
@@ -13,7 +13,7 @@ use crate::table_builder::{self, Footer};
 use crate::types::{current_key_val, LdbIterator, Shared};
 
 use std::cmp::Ordering;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use integer_encoding::FixedIntWriter;
@@ -33,7 +33,7 @@ fn read_footer(f: &dyn RandomAccess, size: usize) -> Result<Footer> {
 
 #[derive(Clone)]
 pub struct Table {
-    file: Rc<Box<dyn RandomAccess>>,
+    file: Arc<Box<dyn RandomAccess>>,
     file_size: usize,
     cache_id: cache::CacheID,
 
@@ -50,7 +50,7 @@ impl Table {
     fn new_raw(
         opt: Options,
         block_cache: Shared<Cache<Block>>,
-        file: Rc<Box<dyn RandomAccess>>,
+        file: Arc<Box<dyn RandomAccess>>,
         size: usize,
     ) -> Result<Table> {
         let footer = read_footer(file.as_ref().as_ref(), size)?;
@@ -61,7 +61,7 @@ impl Table {
 
         let filter_block_reader =
             Table::read_filter_block(&metaindexblock, file.as_ref().as_ref(), &opt)?;
-        let cache_id = block_cache.borrow_mut().new_cache_id();
+        let cache_id = block_cache.write().unwrap().new_cache_id();
 
         Ok(Table {
             file,
@@ -116,11 +116,11 @@ impl Table {
     pub fn new(
         mut opt: Options,
         block_cache: Shared<Cache<Block>>,
-        file: Rc<Box<dyn RandomAccess>>,
+        file: Arc<Box<dyn RandomAccess>>,
         size: usize,
     ) -> Result<Table> {
-        opt.cmp = Rc::new(Box::new(InternalKeyCmp(opt.cmp.clone())));
-        opt.filter_policy = Rc::new(Box::new(filter::InternalFilterPolicy::new(
+        opt.cmp = Arc::new(Box::new(InternalKeyCmp(opt.cmp.clone())));
+        opt.filter_policy = Arc::new(Box::new(filter::InternalFilterPolicy::new(
             opt.filter_policy,
         )));
         Table::new_raw(opt, block_cache, file, size)
@@ -143,16 +143,19 @@ impl Table {
     /// cache.
     fn read_block(&self, location: &BlockHandle) -> Result<Block> {
         let cachekey = self.block_cache_handle(location.offset());
-        if let Some(block) = self.block_cache.borrow_mut().get(&cachekey) {
+        if let Some(block) = self.block_cache.write().unwrap().get(&cachekey) {
             return Ok(block.clone());
         }
 
-        // Two times as_ref(): First time to get a ref from Rc<>, then one from Box<>.
+        // Two times as_ref(): First time to get a ref from Arc<>, then one from Box<>.
         let b =
             table_block::read_table_block(self.opt.clone(), self.file.as_ref().as_ref(), location)?;
 
         // insert a cheap copy (Rc).
-        self.block_cache.borrow_mut().insert(&cachekey, b.clone());
+        self.block_cache
+            .write()
+            .unwrap()
+            .insert(&cachekey, b.clone());
 
         Ok(b)
     }
@@ -384,7 +387,7 @@ impl LdbIterator for TableIterator {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
+    use std::sync::RwLock;
 
     use crate::compressor::CompressorId;
     use crate::filter::BloomPolicy;
@@ -441,7 +444,7 @@ mod tests {
         let mut opt = options::for_test();
         opt.block_restart_interval = 1;
         opt.block_size = 32;
-        opt.filter_policy = Rc::new(Box::new(BloomPolicy::new(4)));
+        opt.filter_policy = Arc::new(Box::new(BloomPolicy::new(4)));
 
         let mut i = 1_u64;
         let data: Vec<(Vec<u8>, &'static str)> = build_data()
@@ -468,8 +471,8 @@ mod tests {
         (d, size)
     }
 
-    fn wrap_buffer(src: Vec<u8>) -> Rc<Box<dyn RandomAccess>> {
-        Rc::new(Box::new(src))
+    fn wrap_buffer(src: Vec<u8>) -> Arc<Box<dyn RandomAccess>> {
+        Arc::new(Box::new(src))
     }
 
     #[test]
@@ -502,21 +505,21 @@ mod tests {
             let mut iter = table.iter();
 
             // index/metaindex blocks are not cached. That'd be a waste of memory.
-            assert_eq!(bc.borrow().count(), 0);
+            assert_eq!(bc.read().unwrap().count(), 0);
             iter.next();
-            assert_eq!(bc.borrow().count(), 1);
+            assert_eq!(bc.read().unwrap().count(), 1);
             // This may fail if block parameters or data change. In that case, adapt it.
             iter.next();
             iter.next();
             iter.next();
             iter.next();
-            assert_eq!(bc.borrow().count(), 2);
+            assert_eq!(bc.read().unwrap().count(), 2);
         }
 
         println!(
             "weak = {}, strong = {}",
-            std::rc::Rc::<RefCell<cache::Cache<block::Block>>>::weak_count(&bc),
-            std::rc::Rc::<RefCell<cache::Cache<block::Block>>>::strong_count(&bc)
+            std::sync::Arc::<RwLock<cache::Cache<block::Block>>>::weak_count(&bc),
+            std::sync::Arc::<RwLock<cache::Cache<block::Block>>>::strong_count(&bc)
         );
     }
 
@@ -708,7 +711,7 @@ mod tests {
             assert_eq!(Ok(Some((k.into(), v.into()))), r);
         }
 
-        assert_eq!(bc.borrow().count(), 3);
+        assert_eq!(bc.read().unwrap().count(), 3);
 
         // test that filters work and don't return anything at all.
         assert!(table.get(b"aaa").unwrap().is_none());

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,9 +2,9 @@
 
 use crate::error::{err, Result, StatusCode};
 
-use std::cell::RefCell;
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::RwLock;
 
 use bytes::Bytes;
 
@@ -16,10 +16,10 @@ pub type SequenceNumber = u64;
 pub const MAX_SEQUENCE_NUMBER: SequenceNumber = (1 << 56) - 1;
 
 /// A shared thingy with interior mutability.
-pub type Shared<T> = Rc<RefCell<T>>;
+pub type Shared<T> = Arc<RwLock<T>>;
 
-pub fn share<T>(t: T) -> Rc<RefCell<T>> {
-    Rc::new(RefCell::new(t))
+pub fn share<T>(t: T) -> Arc<RwLock<T>> {
+    Arc::new(RwLock::new(t))
 }
 
 #[derive(PartialEq)]

--- a/src/version.rs
+++ b/src/version.rs
@@ -791,6 +791,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::type_complexity)]
     fn test_version_get_simple() {
         let v = make_version().0;
         let cases: &[(&[u8], u64, Result<Option<Vec<u8>>>)] = &[

--- a/src/version.rs
+++ b/src/version.rs
@@ -8,7 +8,7 @@ use crate::types::{FileMetaData, FileNum, LdbIterator, Shared, MAX_SEQUENCE_NUMB
 use bytes::Bytes;
 use std::cmp::Ordering;
 use std::default::Default;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// FileMetaHandle is a reference-counted FileMetaData object with interior mutability. This is
 /// necessary to provide a shared metadata container that can be modified while referenced by e.g.
@@ -23,7 +23,7 @@ pub struct GetStats {
 
 pub struct Version {
     table_cache: Shared<TableCache>,
-    user_cmp: Rc<Box<dyn Cmp>>,
+    user_cmp: Arc<Box<dyn Cmp>>,
     pub files: [Vec<FileMetaHandle>; NUM_LEVELS],
 
     pub file_to_compact: Option<FileMetaHandle>,
@@ -35,7 +35,7 @@ pub struct Version {
 struct DoSearchResult(Option<(Vec<u8>, Vec<u8>)>, Vec<FileMetaHandle>);
 
 impl Version {
-    pub fn new(cache: Shared<TableCache>, ucmp: Rc<Box<dyn Cmp>>) -> Version {
+    pub fn new(cache: Shared<TableCache>, ucmp: Arc<Box<dyn Cmp>>) -> Version {
         Version {
             table_cache: cache,
             user_cmp: ucmp,
@@ -84,7 +84,12 @@ impl Version {
                 // We receive both key and value from the table. Because we're using InternalKey
                 // keys, we now need to check whether the found entry's user key is equal to the
                 // one we're looking for (get() just returns the next-bigger key).
-                if let Ok(Some((k, v))) = self.table_cache.borrow_mut().get(f.borrow().num, ikey) {
+                if let Ok(Some((k, v))) = self
+                    .table_cache
+                    .read()
+                    .unwrap()
+                    .get(f.read().unwrap().num, ikey)
+                {
                     // We don't need to check the sequence number; get() will not return an entry
                     // with a higher sequence number than the one in the supplied key.
                     let (typ, _, foundkey) = parse_internal_key(&k);
@@ -111,7 +116,7 @@ impl Version {
         let files = &self.files[0];
         levels[0].reserve(files.len());
         for f_ in files {
-            let f = f_.borrow();
+            let f = f_.read().unwrap();
             let (fsmallest, flargest) = (
                 parse_internal_key(&f.smallest).2,
                 parse_internal_key(&f.largest).2,
@@ -123,13 +128,13 @@ impl Version {
             }
         }
         // Sort by newest first.
-        levels[0].sort_by(|a, b| b.borrow().num.cmp(&a.borrow().num));
+        levels[0].sort_by(|a, b| b.read().unwrap().num.cmp(&a.read().unwrap().num));
 
         let icmp = InternalKeyCmp(self.user_cmp.clone());
         (1..NUM_LEVELS).for_each(|level| {
             let files = &self.files[level];
             if let Some(ix) = find_file(&icmp, files, ikey) {
-                let f = files[ix].borrow();
+                let f = files[ix].read().unwrap();
                 let fsmallest = parse_internal_key(&f.smallest).2;
                 if self.user_cmp.cmp(ukey, fsmallest) >= Ordering::Equal {
                     levels[level].push(files[ix].clone());
@@ -150,7 +155,7 @@ impl Version {
             }
             let filedesc: Vec<(FileNum, usize)> = fs
                 .iter()
-                .map(|f| (f.borrow().num, f.borrow().size))
+                .map(|f| (f.read().unwrap().num, f.read().unwrap().size))
                 .collect();
             let desc = format!(
                 "level {}: {} files, {} bytes ({:?}); ",
@@ -225,12 +230,12 @@ impl Version {
     /// compaction candidates. It returns true if a compaction makes sense.
     pub fn update_stats(&mut self, stats: GetStats) -> bool {
         if let Some(file) = stats.file {
-            if file.borrow().allowed_seeks <= 1 && self.file_to_compact.is_none() {
+            if file.read().unwrap().allowed_seeks <= 1 && self.file_to_compact.is_none() {
                 self.file_to_compact = Some(file);
                 self.file_to_compact_lvl = stats.level;
                 return true;
-            } else if file.borrow().allowed_seeks > 0 {
-                file.borrow_mut().allowed_seeks -= 1;
+            } else if file.read().unwrap().allowed_seeks > 0 {
+                file.write().unwrap().allowed_seeks -= 1;
             }
         }
         false
@@ -242,7 +247,7 @@ impl Version {
         let mut max = 0;
         for lvl in 1..NUM_LEVELS - 1 {
             for f in &self.files[lvl] {
-                let f = f.borrow();
+                let f = f.read().unwrap();
                 let ols = self.overlapping_inputs(lvl + 1, &f.smallest, &f.largest);
                 let sum = total_size(ols.iter());
                 if sum > max {
@@ -313,7 +318,7 @@ impl Version {
         ) -> DoSearchResult {
             let mut inputs = vec![];
             for f_ in myself.files[level].iter() {
-                let f = f_.borrow();
+                let f = f_.read().unwrap();
                 let (fsmallest, flargest) = (
                     parse_internal_key(&f.smallest).2,
                     parse_internal_key(&f.largest).2,
@@ -367,8 +372,9 @@ impl Version {
         for f in &self.files[0] {
             iters.push(Box::new(
                 self.table_cache
-                    .borrow_mut()
-                    .get_table(f.borrow().num)?
+                    .read()
+                    .unwrap()
+                    .get_table(f.read().unwrap().num)?
                     .iter(),
             ));
         }
@@ -388,7 +394,7 @@ impl Version {
 pub fn new_version_iter(
     files: Vec<FileMetaHandle>,
     cache: Shared<TableCache>,
-    ucmp: Rc<Box<dyn Cmp>>,
+    ucmp: Arc<Box<dyn Cmp>>,
 ) -> VersionIter {
     VersionIter {
         files,
@@ -433,8 +439,9 @@ impl LdbIterator for VersionIter {
         // Initialize iterator or load next table.
         if let Ok(tbl) = self
             .cache
-            .borrow_mut()
-            .get_table(self.files[self.current_ix].borrow().num)
+            .write()
+            .unwrap()
+            .get_table(self.files[self.current_ix].read().unwrap().num)
         {
             self.current = Some(tbl.iter());
         } else {
@@ -453,8 +460,9 @@ impl LdbIterator for VersionIter {
         if let Some(ix) = find_file(&self.cmp, &self.files, key) {
             if let Ok(tbl) = self
                 .cache
-                .borrow_mut()
-                .get_table(self.files[ix].borrow().num)
+                .write()
+                .unwrap()
+                .get_table(self.files[ix].read().unwrap().num)
             {
                 let mut iter = tbl.iter();
                 iter.seek(key);
@@ -481,9 +489,9 @@ impl LdbIterator for VersionIter {
             } else if self.current_ix > 0 {
                 let f = &self.files[self.current_ix - 1];
                 // Find previous table, seek to last entry.
-                if let Ok(tbl) = self.cache.borrow_mut().get_table(f.borrow().num) {
+                if let Ok(tbl) = self.cache.read().unwrap().get_table(f.read().unwrap().num) {
                     let mut iter = tbl.iter();
-                    iter.seek(&f.borrow().largest);
+                    iter.seek(&f.read().unwrap().largest);
                     // The saved largest key must be in the table.
                     assert!(iter.valid());
                     self.current_ix -= 1;
@@ -499,19 +507,19 @@ impl LdbIterator for VersionIter {
 
 /// total_size returns the sum of sizes of the given files.
 pub fn total_size<'a, I: Iterator<Item = &'a FileMetaHandle>>(files: I) -> usize {
-    files.fold(0, |a, f| a + f.borrow().size)
+    files.fold(0, |a, f| a + f.read().unwrap().size)
 }
 
 /// key_is_after_file returns true if the given user key is larger than the largest key in f.
 fn key_is_after_file(cmp: &InternalKeyCmp, key: UserKey<'_>, f: &FileMetaHandle) -> bool {
-    let f = f.borrow();
+    let f = f.read().unwrap();
     let ulargest = parse_internal_key(&f.largest).2;
     !key.is_empty() && cmp.cmp_inner(key, ulargest) == Ordering::Greater
 }
 
 /// key_is_before_file returns true if the given user key is larger than the largest key in f.
 fn key_is_before_file(cmp: &InternalKeyCmp, key: UserKey<'_>, f: &FileMetaHandle) -> bool {
-    let f = f.borrow();
+    let f = f.read().unwrap();
     let usmallest = parse_internal_key(&f.smallest).2;
     !key.is_empty() && cmp.cmp_inner(key, usmallest) == Ordering::Less
 }
@@ -527,7 +535,7 @@ fn find_file(
     let (mut left, mut right) = (0, files.len());
     while left < right {
         let mid = (left + right) / 2;
-        if cmp.cmp(&files[mid].borrow().largest, key) == Ordering::Less {
+        if cmp.cmp(&files[mid].read().unwrap().largest, key) == Ordering::Less {
             left = mid + 1;
         } else {
             right = mid;
@@ -641,7 +649,7 @@ pub mod testutil {
             contents[contents.len() - 1].0,
             startseq + (contents.len() - 1) as u64,
         );
-        f.borrow_mut().size = tbl.finish().unwrap();
+        f.write().unwrap().size = tbl.finish().unwrap();
         f
     }
 
@@ -717,7 +725,7 @@ pub mod testutil {
         let t9 = write_table(env.as_ref().as_ref(), f9, 1, 9);
 
         let cache = TableCache::new("db", opts.clone(), share(Cache::new(128)), 100);
-        let mut v = Version::new(share(cache), Rc::new(Box::new(DefaultCmp)));
+        let mut v = Version::new(share(cache), Arc::new(Box::new(DefaultCmp)));
         v.files[0] = vec![t1, t2];
         v.files[1] = vec![t3, t4, t5];
         v.files[2] = vec![t6, t7];
@@ -767,14 +775,14 @@ mod tests {
         let v = make_version().0;
         let iters = v.new_iters().unwrap();
         let mut opt = options::for_test();
-        opt.cmp = Rc::new(Box::new(InternalKeyCmp(Rc::new(Box::new(DefaultCmp)))));
+        opt.cmp = Arc::new(Box::new(InternalKeyCmp(Arc::new(Box::new(DefaultCmp)))));
 
         let mut miter = MergingIter::new(opt.cmp.clone(), iters);
         assert_eq!(LdbIteratorIter::wrap(&mut miter).count(), 30);
 
         // Check that all elements are in order.
         let init = LookupKey::new(b"000", MAX_SEQUENCE_NUMBER);
-        let cmp = InternalKeyCmp(Rc::new(Box::new(DefaultCmp)));
+        let cmp = InternalKeyCmp(Arc::new(Box::new(DefaultCmp)));
         LdbIteratorIter::wrap(&mut miter).fold(init.internal_key().to_vec(), |b, (k, _)| {
             assert!(cmp.cmp(&b, &k) == Ordering::Less);
             k
@@ -829,13 +837,13 @@ mod tests {
         // Overlapped by tables 1 and 2.
         let ol = v.get_overlapping(LookupKey::new(b"aay", 50).internal_key());
         // Check that sorting order is newest-first in L0.
-        assert_eq!(2, ol[0][0].borrow().num);
+        assert_eq!(2, ol[0][0].read().unwrap().num);
         // Check that table from L1 matches.
-        assert_eq!(3, ol[1][0].borrow().num);
+        assert_eq!(3, ol[1][0].read().unwrap().num);
 
         let ol = v.get_overlapping(LookupKey::new(b"cb", 50).internal_key());
-        assert_eq!(3, ol[1][0].borrow().num);
-        assert_eq!(6, ol[2][0].borrow().num);
+        assert_eq!(3, ol[1][0].read().unwrap().num);
+        assert_eq!(6, ol[2][0].read().unwrap().num);
 
         let ol = v.get_overlapping(LookupKey::new(b"x", 50).internal_key());
         (0..NUM_LEVELS).for_each(|i| {
@@ -889,8 +897,8 @@ mod tests {
             let to = LookupKey::new("aae".as_bytes(), 0);
             let r = v.overlapping_inputs(0, from.internal_key(), to.internal_key());
             assert_eq!(r.len(), 2);
-            assert_eq!(r[0].borrow().num, 1);
-            assert_eq!(r[1].borrow().num, 2);
+            assert_eq!(r[0].read().unwrap().num, 1);
+            assert_eq!(r[1].read().unwrap().num, 2);
         }
         {
             let from = LookupKey::new("cab".as_bytes(), MAX_SEQUENCE_NUMBER);
@@ -898,7 +906,7 @@ mod tests {
             // expect one file.
             let r = v.overlapping_inputs(1, from.internal_key(), to.internal_key());
             assert_eq!(r.len(), 1);
-            assert_eq!(r[0].borrow().num, 3);
+            assert_eq!(r[0].read().unwrap().num, 3);
         }
         {
             let from = LookupKey::new("cab".as_bytes(), MAX_SEQUENCE_NUMBER);
@@ -906,9 +914,9 @@ mod tests {
             let r = v.overlapping_inputs(1, from.internal_key(), to.internal_key());
             // Assert that correct number of files and correct files were returned.
             assert_eq!(r.len(), 3);
-            assert_eq!(r[0].borrow().num, 3);
-            assert_eq!(r[1].borrow().num, 4);
-            assert_eq!(r[2].borrow().num, 5);
+            assert_eq!(r[0].read().unwrap().num, 3);
+            assert_eq!(r[1].read().unwrap().num, 4);
+            assert_eq!(r[2].read().unwrap().num, 5);
         }
         {
             let from = LookupKey::new("hhh".as_bytes(), MAX_SEQUENCE_NUMBER);
@@ -931,7 +939,7 @@ mod tests {
 
         for fs in v.files.iter() {
             for f in fs {
-                f.borrow_mut().allowed_seeks = 0;
+                f.write().unwrap().allowed_seeks = 0;
             }
         }
         assert!(v.record_read_sample(k.internal_key()));
@@ -941,7 +949,7 @@ mod tests {
     fn test_version_key_ordering() {
         time_test!();
         let fmh = new_file(1, &[1, 0, 0], 0, &[2, 0, 0], 1);
-        let cmp = InternalKeyCmp(Rc::new(Box::new(DefaultCmp)));
+        let cmp = InternalKeyCmp(Arc::new(Box::new(DefaultCmp)));
 
         // Keys before file.
         for k in &[&[0][..], &[1], &[1, 0], &[0, 9, 9, 9]] {
@@ -980,7 +988,7 @@ mod tests {
             new_file(2, &[2, 5, 0], 0, &[4, 0, 0], 1),
             new_file(3, &[3, 5, 1], 0, &[5, 0, 0], 1),
         ];
-        let cmp = InternalKeyCmp(Rc::new(Box::new(DefaultCmp)));
+        let cmp = InternalKeyCmp(Arc::new(Box::new(DefaultCmp)));
 
         assert!(some_file_overlaps_range(
             &cmp,

--- a/src/version_set.rs
+++ b/src/version_set.rs
@@ -17,14 +17,14 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub struct Compaction {
     level: usize,
     max_file_size: usize,
     input_version: Option<Shared<Version>>,
     level_ixs: [usize; NUM_LEVELS],
-    cmp: Rc<Box<dyn Cmp>>,
+    cmp: Arc<Box<dyn Cmp>>,
     icmp: InternalKeyCmp,
 
     manual: bool,
@@ -72,7 +72,7 @@ impl Compaction {
     pub fn input(&self, parent: usize, ix: usize) -> FileMetaData {
         assert!(parent < 2);
         assert!(ix < self.inputs[parent].len());
-        self.inputs[parent][ix].borrow().clone()
+        self.inputs[parent][ix].read().unwrap().clone()
     }
 
     pub fn num_inputs(&self, parent: usize) -> usize {
@@ -92,7 +92,8 @@ impl Compaction {
     pub fn add_input_deletions(&mut self) {
         for parent in 0..2 {
             for f in &self.inputs[parent] {
-                self.edit.delete_file(self.level + parent, f.borrow().num);
+                self.edit
+                    .delete_file(self.level + parent, f.read().unwrap().num);
             }
         }
     }
@@ -104,9 +105,9 @@ impl Compaction {
         assert!(self.input_version.is_some());
         let inp_version = self.input_version.as_ref().unwrap();
         for level in self.level + 2..NUM_LEVELS {
-            let files = &inp_version.borrow().files[level];
+            let files = &inp_version.read().unwrap().files[level];
             while self.level_ixs[level] < files.len() {
-                let f = files[self.level_ixs[level]].borrow();
+                let f = files[self.level_ixs[level]].read().unwrap();
                 if self.cmp.cmp(k, parse_internal_key(&f.largest).2) <= Ordering::Equal {
                     if self.cmp.cmp(k, parse_internal_key(&f.smallest).2) >= Ordering::Equal {
                         // key is in this file's range, so this is not the base level.
@@ -142,13 +143,13 @@ impl Compaction {
         }
         let grandparents = self.grandparents.as_ref().unwrap();
         while self.grandparent_ix < grandparents.len()
-            && self
-                .icmp
-                .cmp(k, &grandparents[self.grandparent_ix].borrow().largest)
-                == Ordering::Greater
+            && self.icmp.cmp(
+                k,
+                &grandparents[self.grandparent_ix].read().unwrap().largest,
+            ) == Ordering::Greater
         {
             if self.seen_key {
-                self.overlapped_bytes += grandparents[self.grandparent_ix].borrow().size;
+                self.overlapped_bytes += grandparents[self.grandparent_ix].read().unwrap().size;
             }
             self.grandparent_ix += 1;
         }
@@ -180,7 +181,7 @@ pub struct VersionSet {
     current: Option<Shared<Version>>,
     compaction_ptrs: [Bytes; NUM_LEVELS],
 
-    descriptor_log: Option<LogWriter<Box<dyn Write>>>,
+    descriptor_log: Option<LogWriter<Box<dyn std::io::Write + Send + Sync>>>,
 }
 
 impl VersionSet {
@@ -207,7 +208,12 @@ impl VersionSet {
     }
 
     pub fn current_summary(&self) -> String {
-        self.current.as_ref().unwrap().borrow().level_summary()
+        self.current
+            .as_ref()
+            .unwrap()
+            .read()
+            .unwrap()
+            .level_summary()
     }
 
     /// live_files returns the files that are currently active.
@@ -215,8 +221,8 @@ impl VersionSet {
         let mut files = HashSet::new();
         if let Some(ref version) = self.current {
             for level in 0..NUM_LEVELS {
-                for file in &version.borrow().files[level] {
-                    files.insert(file.borrow().num);
+                for file in &version.read().unwrap().files[level] {
+                    files.insert(file.read().unwrap().num);
                 }
             }
         }
@@ -255,22 +261,23 @@ impl VersionSet {
     pub fn needs_compaction(&self) -> bool {
         assert!(self.current.is_some());
         let v = self.current.as_ref().unwrap();
-        let v = v.borrow();
+        let v = v.read().unwrap();
         v.compaction_score.unwrap_or(0.0) >= 1.0 || v.file_to_compact.is_some()
     }
 
     fn approximate_offset(&self, v: &Shared<Version>, key: InternalKey<'_>) -> usize {
         let mut offset = 0;
         for level in 0..NUM_LEVELS {
-            for f in &v.borrow().files[level] {
-                if self.opt.cmp.cmp(&f.borrow().largest, key) <= Ordering::Equal {
-                    offset += f.borrow().size;
-                } else if self.opt.cmp.cmp(&f.borrow().smallest, key) == Ordering::Greater {
+            for f in &v.read().unwrap().files[level] {
+                if self.opt.cmp.cmp(&f.read().unwrap().largest, key) <= Ordering::Equal {
+                    offset += f.read().unwrap().size;
+                } else if self.opt.cmp.cmp(&f.read().unwrap().smallest, key) == Ordering::Greater {
                     // In higher levels, files are sorted; we don't need to search further.
                     if level > 0 {
                         break;
                     }
-                } else if let Ok(tbl) = self.cache.borrow_mut().get_table(f.borrow().num) {
+                } else if let Ok(tbl) = self.cache.read().unwrap().get_table(f.read().unwrap().num)
+                {
                     offset += tbl.approx_offset_of(key);
                 }
             }
@@ -281,7 +288,7 @@ impl VersionSet {
     pub fn pick_compaction(&mut self) -> Option<Compaction> {
         assert!(self.current.is_some());
         let current = self.current();
-        let current = current.borrow();
+        let current = current.read().unwrap();
 
         let mut c = Compaction::new(&self.opt, 0, self.current.clone());
         let level;
@@ -295,7 +302,7 @@ impl VersionSet {
                 if self.compaction_ptrs[level].is_empty()
                     || self
                         .cmp
-                        .cmp(&f.borrow().largest, &self.compaction_ptrs[level])
+                        .cmp(&f.read().unwrap().largest, &self.compaction_ptrs[level])
                         == Ordering::Greater
                 {
                     c.add_input(0, f.clone());
@@ -340,7 +347,8 @@ impl VersionSet {
             .current
             .as_ref()
             .unwrap()
-            .borrow()
+            .read()
+            .unwrap()
             .overlapping_inputs(level, from, to);
         if inputs.is_empty() {
             return None;
@@ -349,7 +357,7 @@ impl VersionSet {
         if level > 0 {
             let mut total = 0;
             for i in 0..inputs.len() {
-                total += inputs[i].borrow().size;
+                total += inputs[i].read().unwrap().size;
                 if total > self.opt.max_file_size {
                     inputs.truncate(i + 1);
                     break;
@@ -367,7 +375,7 @@ impl VersionSet {
     fn setup_other_inputs(&mut self, compaction: &mut Compaction) {
         assert!(self.current.is_some());
         let current = self.current.as_ref().unwrap();
-        let current = current.borrow();
+        let current = current.read().unwrap();
 
         let level = compaction.level;
         let (mut smallest, mut largest) = get_range(&self.cmp, compaction.inputs[0].iter());
@@ -428,11 +436,13 @@ impl VersionSet {
         // Set the list of grandparent (l+2) inputs to the files overlapped by the current overall
         // range.
         if level + 2 < NUM_LEVELS {
-            let grandparents = self.current.as_ref().unwrap().borrow().overlapping_inputs(
-                level + 2,
-                &allstart,
-                &alllimit,
-            );
+            let grandparents = self
+                .current
+                .as_ref()
+                .unwrap()
+                .read()
+                .unwrap()
+                .overlapping_inputs(level + 2, &allstart, &alllimit);
             compaction.grandparents = Some(grandparents);
         }
 
@@ -462,12 +472,12 @@ impl VersionSet {
             }
         }
 
-        let current = self.current.as_ref().unwrap().borrow();
+        let current = self.current.as_ref().unwrap().read().unwrap();
         // Save files.
         for level in 0..NUM_LEVELS {
             let fs = &current.files[level];
             for f in fs {
-                edit.add_file(level, f.borrow().clone());
+                edit.add_file(level, f.read().unwrap().clone());
             }
         }
         self.descriptor_log
@@ -714,14 +724,14 @@ impl VersionSet {
                 // Add individual iterators for L0 tables.
                 for fi in 0..c.num_inputs(i) {
                     let f = &c.inputs[i][fi];
-                    let s = self.cache.borrow_mut().get_table(f.borrow().num);
+                    let s = self.cache.read().unwrap().get_table(f.read().unwrap().num);
                     if let Ok(tbl) = s {
                         iters.push(Box::new(tbl.iter()));
                     } else {
                         log!(
                             self.opt.log,
                             "error opening table {}: {}",
-                            f.borrow().num,
+                            f.read().unwrap().num,
                             s.err().unwrap()
                         );
                     }
@@ -736,7 +746,7 @@ impl VersionSet {
             }
         }
         assert!(iters.len() <= cap);
-        let cmp: Rc<Box<dyn Cmp>> = Rc::new(Box::new(self.cmp.clone()));
+        let cmp: Arc<Box<dyn Cmp>> = Arc::new(Box::new(self.cmp.clone()));
         Box::new(MergingIter::new(cmp, iters))
     }
 }
@@ -789,7 +799,10 @@ impl Builder {
         f: FileMetaHandle,
     ) {
         // Only add file if it's not already deleted.
-        if self.deleted[level].iter().any(|d| *d == f.borrow().num) {
+        if self.deleted[level]
+            .iter()
+            .any(|d| *d == f.read().unwrap().num)
+        {
             return;
         }
         {
@@ -798,8 +811,8 @@ impl Builder {
                 // File must be after last file in level.
                 assert_eq!(
                     cmp.cmp(
-                        &files[files.len() - 1].borrow().largest,
-                        &f.borrow().smallest
+                        &files[files.len() - 1].read().unwrap().largest,
+                        &f.read().unwrap().smallest
                     ),
                     Ordering::Less
                 );
@@ -814,16 +827,16 @@ impl Builder {
         for level in 0..NUM_LEVELS {
             sort_files_by_smallest(cmp, &mut self.added[level]);
             // The base version should already have sorted files.
-            sort_files_by_smallest(cmp, &mut base.borrow_mut().files[level]);
+            sort_files_by_smallest(cmp, &mut base.write().unwrap().files[level]);
 
             let added = self.added[level].clone();
-            let basefiles = base.borrow().files[level].clone();
+            let basefiles = base.read().unwrap().files[level].clone();
             v.files[level].reserve(basefiles.len() + self.added[level].len());
 
             let iadded = added.into_iter();
             let ibasefiles = basefiles.into_iter();
             let merged = merge_iters(iadded, ibasefiles, |a, b| {
-                cmp.cmp(&a.borrow().smallest, &b.borrow().smallest)
+                cmp.cmp(&a.read().unwrap().smallest, &b.read().unwrap().smallest)
             });
             for m in merged {
                 self.maybe_add_file(cmp, v, level, m);
@@ -835,8 +848,8 @@ impl Builder {
             }
             for i in 1..v.files[level].len() {
                 let (prev_end, this_begin) = (
-                    &v.files[level][i - 1].borrow().largest,
-                    &v.files[level][i].borrow().smallest,
+                    &v.files[level][i - 1].read().unwrap().largest,
+                    &v.files[level][i].read().unwrap().smallest,
                 );
                 assert!(cmp.cmp(prev_end, this_begin) < Ordering::Equal);
             }
@@ -897,7 +910,7 @@ pub fn set_current_file<P: AsRef<Path>>(
 
 /// sort_files_by_smallest sorts the list of files by the smallest keys of the files.
 fn sort_files_by_smallest<C: Cmp>(cmp: &C, files: &mut [FileMetaHandle]) {
-    files.sort_by(|a, b| cmp.cmp(&a.borrow().smallest, &b.borrow().smallest))
+    files.sort_by(|a, b| cmp.cmp(&a.read().unwrap().smallest, &b.read().unwrap().smallest))
 }
 
 /// merge_iters merges and collects the items from two sorted iterators.
@@ -953,12 +966,12 @@ fn get_range<'a, C: Cmp, I: Iterator<Item = &'a FileMetaHandle>>(
     let mut largest = None;
     for f in files {
         if smallest.is_none() {
-            smallest = Some(f.borrow().smallest.clone());
+            smallest = Some(f.read().unwrap().smallest.clone());
         }
         if largest.is_none() {
-            largest = Some(f.borrow().largest.clone());
+            largest = Some(f.read().unwrap().largest.clone());
         }
-        let f = f.borrow();
+        let f = f.read().unwrap();
         if c.cmp(&f.smallest, smallest.as_ref().unwrap()) == Ordering::Less {
             smallest = Some(f.smallest.clone());
         }
@@ -1081,7 +1094,7 @@ mod tests {
         assert_eq!(1, v2.files[0].len());
         // File was added to L1.
         assert_eq!(4, v2.files[1].len());
-        assert_eq!(21, v2.files[1][3].borrow().num);
+        assert_eq!(21, v2.files[1][3].read().unwrap().num);
     }
 
     #[test]
@@ -1122,8 +1135,14 @@ mod tests {
             assert_eq!(10, vs.log_num);
             assert_eq!(21, vs.next_file_num);
             assert_eq!(30, vs.last_seq);
-            assert_eq!(0, vs.current.as_ref().unwrap().borrow().files[0].len());
-            assert_eq!(0, vs.current.as_ref().unwrap().borrow().files[1].len());
+            assert_eq!(
+                0,
+                vs.current.as_ref().unwrap().read().unwrap().files[0].len()
+            );
+            assert_eq!(
+                0,
+                vs.current.as_ref().unwrap().read().unwrap().files[1].len()
+            );
             assert_eq!(35, vs.write_snapshot().unwrap());
         }
 
@@ -1155,8 +1174,14 @@ mod tests {
 
             // The previous "compaction" should have added one file to the first level in the
             // current version.
-            assert_eq!(0, vs.current.as_ref().unwrap().borrow().files[0].len());
-            assert_eq!(1, vs.current.as_ref().unwrap().borrow().files[1].len());
+            assert_eq!(
+                0,
+                vs.current.as_ref().unwrap().read().unwrap().files[0].len()
+            );
+            assert_eq!(
+                1,
+                vs.current.as_ref().unwrap().read().unwrap().files[1].len()
+            );
             assert_eq!(63, vs.write_snapshot().unwrap());
         }
     }
@@ -1175,7 +1200,7 @@ mod tests {
         assert!(vs.live_files().contains(&3));
 
         let v = vs.current();
-        let v = v.borrow();
+        let v = v.read().unwrap();
         // num_level_bytes()
         assert_eq!(483, v.num_level_bytes(0));
         assert_eq!(651, v.num_level_bytes(1));
@@ -1213,12 +1238,12 @@ mod tests {
         // Seek compaction
         {
             let current = vs.current();
-            current.borrow_mut().compaction_score = None;
-            current.borrow_mut().compaction_level = None;
-            current.borrow_mut().file_to_compact_lvl = 1;
+            current.write().unwrap().compaction_score = None;
+            current.write().unwrap().compaction_level = None;
+            current.write().unwrap().file_to_compact_lvl = 1;
 
-            let fmd = current.borrow().files[1][0].clone();
-            current.borrow_mut().file_to_compact = Some(fmd);
+            let fmd = current.read().unwrap().files[1][0].clone();
+            current.write().unwrap().file_to_compact = Some(fmd);
 
             let c = vs.pick_compaction().unwrap();
             assert_eq!(3, c.inputs[0].len()); // inputs on l+0 are expanded.
@@ -1230,7 +1255,7 @@ mod tests {
 
     /// iterator_properties tests that it contains len elements and that they are ordered in
     /// ascending order by cmp.
-    fn iterator_properties<It: LdbIterator>(mut it: It, len: usize, cmp: Rc<Box<dyn Cmp>>) {
+    fn iterator_properties<It: LdbIterator>(mut it: It, len: usize, cmp: Arc<Box<dyn Cmp>>) {
         let mut wr = LdbIteratorIter::wrap(&mut it);
         let first = wr.next().unwrap();
         let mut count = 1;
@@ -1295,7 +1320,7 @@ mod tests {
             iterator_properties(
                 vs.make_input_iterator(&c),
                 12,
-                Rc::new(Box::new(vs.cmp.clone())),
+                Arc::new(Box::new(vs.cmp.clone())),
             );
 
             // Expand input range on higher level.
@@ -1310,7 +1335,7 @@ mod tests {
             iterator_properties(
                 vs.make_input_iterator(&c),
                 12,
-                Rc::new(Box::new(vs.cmp.clone())),
+                Arc::new(Box::new(vs.cmp.clone())),
             );
 
             // is_trivial_move
@@ -1351,7 +1376,7 @@ mod tests {
                 .unwrap();
             for inp in &[(0, 0, 1), (0, 1, 2), (1, 0, 3)] {
                 let f = &c.inputs[inp.0][inp.1];
-                assert_eq!(inp.2, f.borrow().num);
+                assert_eq!(inp.2, f.read().unwrap().num);
             }
             c.add_input_deletions();
             assert_eq!(23, c.edit().encode().len())


### PR DESCRIPTION
 This PR is an attempt to eliminate unsafe blocks within the
  codebase by replacing custom pointer-based data structures with safe, index-based
  implementations and modern Rust concurrency primitives.
  All tests continue to pass.

I wanted to get something out to start a discussion, but I'm happy to adjust things.

  Each commit in this chain is self-contained and reviewable individually:
   * SkipMap: Replaced the unsafe, pointer-based Box implementation with a safe,
     index-based Vec arena.
   * LRU Cache: Replaced the custom unsafe doubly-linked list with a safe
     index/free-list implementation.
   * Concurrency: Replaced Rc/RefCell with Arc/RwLock, allowing us to safely drop
     the unsafe impl Send for the DB.
   * Examples: Replaced static mut with OnceLock in the kvserver example.
   * Clippy: A preliminary commit to fix existing clippy warnings. (Note: I am
     happy to revert/drop this commit if it is too unrelated. It was included
     primarily so I could maintain a clean clippy state while working on the later
     refactoring commits).

<details><summary>Benchmarks</summary>
<p>

 ### Before
   running 2 tests
   test bench_cache_get_hit      ... bench:          23 ns/iter (+/- 0)
   test bench_cache_insert_evict ... bench:          75 ns/iter (+/- 4)

   running 4 tests
   test bench_btree_insert   ... bench:       2,458 ns/iter (+/- 343)
   test bench_gen_key_val    ... bench:          86 ns/iter (+/- 4)
   test bench_hashmap_insert ... bench:         957 ns/iter (+/- 88)
   test bench_skipmap_insert ... bench:       6,074 ns/iter (+/- 1,590)

   ### After

   running 2 tests
   test bench_cache_get_hit      ... bench:          22 ns/iter (+/- 0)
   test bench_cache_insert_evict ... bench:          89 ns/iter (+/- 7)

   running 4 tests
   test bench_btree_insert   ... bench:       2,449 ns/iter (+/- 657)
   test bench_gen_key_val    ... bench:          86 ns/iter (+/- 1)
   test bench_hashmap_insert ... bench:       1,121 ns/iter (+/- 64)
   test bench_skipmap_insert ... bench:       4,334 ns/iter (+/- 419)

</p>
</details> 

Some limitations:

- `RwLock` might be overkill, but I wanted to get something up and working quickly. The performance might be worse in lock contention scenarios
- If the locks get poisoned, the `.unwrap()`s will panic and can cascade, though the `RefCell` code would also panic on borrow violations
- The arena-based structures don't shrink and might be a bit wasteful in terms of memory, though it's bounded by capacity

AI was used in creating these changes, though they are human-reviewed
